### PR TITLE
Merging stop_order into develop branch

### DIFF
--- a/Examples/RLvsTBHPexample2/input/pathweight_ft.txt
+++ b/Examples/RLvsTBHPexample2/input/pathweight_ft.txt
@@ -5,5 +5,5 @@ all        access           walk           walk_access  preferred_delay_min 2.0
 all        egress           walk           walk_egress  time_min            0.0
 all        egress           walk           walk_egress  preferred_delay_min 2.0
 all        transit          local_bus      local_bus    in_vehicle_time_min 1.0
-all        transit          local_bus      local_bus    wait_time_min       2.0
+all        transit          local_bus      local_bus    wait_time_min       2.01
 all        transit          local_bus      local_bus    transfer_penalty    0.0

--- a/Examples/test_network/input/config_ft.txt
+++ b/Examples/test_network/input/config_ft.txt
@@ -7,6 +7,7 @@ output_passenger_trajectories = True
 time_window                   = 30
 create_skims                  = False
 stochastic_dispersion         = 0.2
+stochastic_max_stop_process_count = 1
 stochastic_pathset_size       = 1000
 capacity_constraint           = False
 trace_person_ids              = ['bunnies']

--- a/fasttrips/Assignment.py
+++ b/fasttrips/Assignment.py
@@ -87,6 +87,12 @@ class Assignment:
     #: If unknown use a value between 0.5 and 1. Float.
     STOCH_DISPERSION                = None
 
+    #: Route choice configuration: How many times max times should we process a stop
+    #: during labeling?  Use -1 to specify no max.  Int.
+    #: Setting this to a positive value may increase runtime but may decrease
+    #: pathset quality. (Todo: test/quantify this.)
+    STOCH_MAX_STOP_PROCESS_COUNT    = None
+
     #: Route choice configuration: How many stochastic paths will we generate
     #: (not necessarily unique) to define a path choice set?  Int.
     STOCH_PATHSET_SIZE              = None
@@ -178,6 +184,7 @@ class Assignment:
                       'skim_start_time'                 :'5:00',
                       'skim_end_time'                   :'10:00',
                       'stochastic_dispersion'           :1.0,
+                      'stochastic_max_stop_process_count':-1,
                       'stochastic_pathset_size'         :1000,
                       'capacity_constraint'             :False,
                       'trace_person_ids'                :'None',
@@ -208,6 +215,7 @@ class Assignment:
                                                    parser.get       ('fasttrips','skim_end_time'),'%H:%M')
         Assignment.STOCH_DISPERSION              = parser.getfloat  ('fasttrips','stochastic_dispersion')
         Assignment.STOCH_PATHSET_SIZE            = parser.getint    ('fasttrips','stochastic_pathset_size')
+        Assignment.STOCH_MAX_STOP_PROCESS_COUNT  = parser.getint    ('fasttrips','stochastic_max_stop_process_count')
         Assignment.CAPACITY_CONSTRAINT           = parser.getboolean('fasttrips','capacity_constraint')
         Assignment.TRACE_PERSON_IDS         = eval(parser.get       ('fasttrips','trace_person_ids'))
         Assignment.PREPEND_ROUTE_ID_TO_TRIP_ID   = parser.getboolean('fasttrips','prepend_route_id_to_trip_id')
@@ -247,6 +255,7 @@ class Assignment:
         parser.set('fasttrips','skim_start_time',               Assignment.SKIM_START_TIME.strftime('%H:%M'))
         parser.set('fasttrips','skim_end_time',                 Assignment.SKIM_END_TIME.strftime('%H:%M'))
         parser.set('fasttrips','stochastic_dispersion',         '%f' % Assignment.STOCH_DISPERSION)
+        parser.set('fasttrips','stochastic_max_stop_process_count', '%d' % Assignment.STOCH_MAX_STOP_PROCESS_COUNT)
         parser.set('fasttrips','stochastic_pathset_size',       '%d' % Assignment.STOCH_PATHSET_SIZE)
         parser.set('fasttrips','capacity_constraint',           'True' if Assignment.CAPACITY_CONSTRAINT else 'False')
         parser.set('fasttrips','trace_person_ids',              '%s' % str(Assignment.TRACE_PERSON_IDS))
@@ -280,7 +289,8 @@ class Assignment:
         _fasttrips.initialize_parameters(Assignment.TIME_WINDOW.total_seconds()/60.0,
                                          Assignment.BUMP_BUFFER.total_seconds()/60.0,
                                          Assignment.STOCH_PATHSET_SIZE,
-                                         Assignment.STOCH_DISPERSION)
+                                         Assignment.STOCH_DISPERSION,
+                                         Assignment.STOCH_MAX_STOP_PROCESS_COUNT)
 
     @staticmethod
     def set_fasttrips_bump_wait(bump_wait_df):

--- a/fasttrips/FastTrips.py
+++ b/fasttrips/FastTrips.py
@@ -17,14 +17,15 @@ from operator import attrgetter
 import pandas
 import transitfeed
 
-from .Assignment import Assignment
-from .Logger import FastTripsLogger, setupLogging
-from .Passenger import Passenger
-from .Route import Route
-from .Stop import Stop
-from .TAZ import TAZ
-from .Transfer import Transfer
-from .Trip import Trip
+from .Assignment  import Assignment
+from .Logger      import FastTripsLogger, setupLogging
+from .Passenger   import Passenger
+from .Performance import Performance
+from .Route       import Route
+from .Stop        import Stop
+from .TAZ         import TAZ
+from .Transfer    import Transfer
+from .Trip        import Trip
 
 class FastTrips:
     """
@@ -198,8 +199,12 @@ class FastTrips:
 
 
     def run_assignment(self, output_dir):
+        # Initialize performance results
+        self.performance = Performance()
+
         # Do it!
         Assignment.assign_paths(output_dir, self)
 
         self.combine_pathset_files()
+        self.performance.write(output_dir)
 

--- a/fasttrips/FastTrips.py
+++ b/fasttrips/FastTrips.py
@@ -191,7 +191,7 @@ class FastTrips:
 
         if pathset_init:
             # sort it by iteration, trip_id_num
-            pathsets_df.sort(columns=['iteration','trip_list_id_num'], inplace=True)
+            pathsets_df.sort_values(by=['iteration','trip_list_id_num'], inplace=True)
             # write it
             pathset_filename = os.path.join(self.output_dir, FastTrips.PATHSET_LOG % "")
             pathsets_df.to_csv(pathset_filename, sep=" ", index=False)

--- a/fasttrips/Path.py
+++ b/fasttrips/Path.py
@@ -331,7 +331,7 @@ class Path:
                                             walktimes_str], axis=1)
 
         print_passengers_df.reset_index(inplace=True)
-        print_passengers_df.sort(columns=['trip_list_id_num'], inplace=True)
+        print_passengers_df.sort_values(by=['trip_list_id_num'], inplace=True)
 
         print_passengers_df.rename(columns=
            {'pathmode'          :'mode',
@@ -363,7 +363,7 @@ class Path:
         """
         # reset columns
         print_pax_exp_df = pax_exp_df.reset_index()
-        print_pax_exp_df.sort(columns=['trip_list_id_num'], inplace=True)
+        print_pax_exp_df.sort_values(by=['trip_list_id_num'], inplace=True)
 
         print_pax_exp_df['A_time_str'] = print_pax_exp_df['A_time'].apply(Util.datetime64_formatter)
         print_pax_exp_df['B_time_str'] = print_pax_exp_df['B_time'].apply(Util.datetime64_formatter)

--- a/fasttrips/Performance.py
+++ b/fasttrips/Performance.py
@@ -1,0 +1,80 @@
+__copyright__ = "Copyright 2016 Contributing Entities"
+__license__   = """
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+import datetime, os
+import pandas
+
+from .Logger    import FastTripsLogger
+from .Passenger import Passenger
+
+class Performance:
+    """
+    Performance class.  Keeps track of performance information
+    (time spent, number of labeling iterations, etc) related to pathfinding
+    in Fast-Trips.
+    """
+    #: Performance column: Iteration
+    PERFORMANCE_COLUMN_ITERATION              = "iteration"
+    #: Performance column: Trip list ID num
+    PERFORMANCE_COLUMN_TRIP_LIST_ID_NUM       = Passenger.TRIP_LIST_COLUMN_TRIP_LIST_ID_NUM
+    #: Performance column: Number of label iterations
+    PERFORMANCE_COLUMN_LABEL_ITERATIONS       = "label iterations"
+    #: Performance column: Maximum number of times a stop was processed
+    PERFORMANCE_COLUMN_MAX_STOP_PROCESS_COUNT = "max stop process count"
+    #: Performance column: Time spent labeling (timedelta)
+    PERFORMANCE_COLUMN_TIME_LABELING          = "time labeling"
+    #: Performance column: Time spent labeling (milliseconds)
+    PERFORMANCE_COLUMN_TIME_LABELING_MS       = "time labeling milliseconds"
+    #: Performance column: Time spent enumerating (timedelta)
+    PERFORMANCE_COLUMN_TIME_ENUMERATING       = "time enumerating"
+    #: Performance column: Time spent enumerating (milliseconds)
+    PERFORMANCE_COLUMN_TIME_ENUMERATING_MS    = "time enumerating milliseconds"
+    #: Performance column: Traced, since this affects performance
+    PERFORMANCE_COLUMN_TRACED                 = "traced"
+
+    #: File with to write performance results
+    OUTPUT_PERFORMANCE_FILE                   = 'ft_output_performance.txt'
+
+    def __init__(self):
+        """
+        Constructor.  Initialize empty dataframe for performance info.
+        """
+        self.performance_df = pandas.DataFrame(columns=[Performance.PERFORMANCE_COLUMN_ITERATION,
+                                                        Performance.PERFORMANCE_COLUMN_TRIP_LIST_ID_NUM,
+                                                        Performance.PERFORMANCE_COLUMN_LABEL_ITERATIONS,
+                                                        Performance.PERFORMANCE_COLUMN_MAX_STOP_PROCESS_COUNT,
+                                                        Performance.PERFORMANCE_COLUMN_TIME_LABELING,
+                                                        Performance.PERFORMANCE_COLUMN_TIME_ENUMERATING])
+
+    def add_info(self, iteration, trip_list_id_num, perf_dict):
+        """
+        Add this row to the performance dataframe.
+        Assumes time values are in milliseconds.
+        """
+        perf_dict[Performance.PERFORMANCE_COLUMN_ITERATION       ] = iteration
+        perf_dict[Performance.PERFORMANCE_COLUMN_TRIP_LIST_ID_NUM] = trip_list_id_num
+
+        # convert milliseconds time to timedeltas
+        perf_dict[Performance.PERFORMANCE_COLUMN_TIME_LABELING   ] = datetime.timedelta(milliseconds=perf_dict[Performance.PERFORMANCE_COLUMN_TIME_LABELING_MS   ])
+        perf_dict[Performance.PERFORMANCE_COLUMN_TIME_ENUMERATING] = datetime.timedelta(milliseconds=perf_dict[Performance.PERFORMANCE_COLUMN_TIME_ENUMERATING_MS])
+
+        self.performance_df = self.performance_df.append(perf_dict, ignore_index=True)
+
+    def write(self, output_dir):
+        """
+        Writes the results to OUTPUT_PERFORMANCE_FILE to a tab-delimited file.
+        """
+        output_filename = os.path.join(output_dir, Performance.OUTPUT_PERFORMANCE_FILE)
+        self.performance_df.to_csv(output_filename, sep="\t", index=False, date_format="")
+        FastTripsLogger.info("Wrote performance info to %s" % output_filename)

--- a/fasttrips/Trip.py
+++ b/fasttrips/Trip.py
@@ -495,7 +495,7 @@ class Trip:
                                    Trip.STOPTIMES_COLUMN_STOP_SEQUENCE]].groupby([Trip.STOPTIMES_COLUMN_STOP_ID,
                                                                                  Trip.TRIPS_COLUMN_ROUTE_ID])
 
-        stop_group_df = stop_group.apply(lambda x: x.sort(Trip.STOPTIMES_COLUMN_DEPARTURE_TIME))
+        stop_group_df = stop_group.apply(lambda x: x.sort_values(Trip.STOPTIMES_COLUMN_DEPARTURE_TIME))
         # set headway, in minutes
         stop_group_shift_df = stop_group_df.shift()
         stop_group_df['headway'] = (stop_group_df[Trip.STOPTIMES_COLUMN_DEPARTURE_TIME] - stop_group_shift_df[Trip.STOPTIMES_COLUMN_DEPARTURE_TIME])/numpy.timedelta64(1,'m')

--- a/fasttrips/__init__.py
+++ b/fasttrips/__init__.py
@@ -18,6 +18,7 @@ from .FastTrips import FastTrips
 from .Logger import FastTripsLogger, setupLogging
 from .Passenger import Passenger
 from .Path import Path
+from .Performance import Performance
 from .Route import Route
 from .Stop import Stop
 from .TAZ import TAZ

--- a/fasttrips/__init__.py
+++ b/fasttrips/__init__.py
@@ -23,6 +23,7 @@ from .Stop import Stop
 from .TAZ import TAZ
 from .Transfer import Transfer
 from .Trip import Trip
+from .Util import Util
 
 __all__ = [
     'Event',

--- a/scripts/compare_output.py
+++ b/scripts/compare_output.py
@@ -239,6 +239,28 @@ def compare_pathset(dir1, dir2):
     FastTripsLogger.debug(" -- diffs --\n" + \
         str(df_diff_summary[['max prob missing from file2','num paths missing from file2']].reset_index().sort_values(by=['max prob missing from file2', 'trip_list_id_num'], ascending=[False,True]).head()) + "\n")
 
+def compare_performance(dir1, dir2):
+    """
+    Compare performance output
+    """
+    filename = "ft_output_performance.txt"
+    filename1 = os.path.join(dir1, filename)
+    filename2 = os.path.join(dir2, filename)
+    FastTripsLogger.info("============== Comparing %s to %s" % (filename1, filename2))
+
+    df1 = pandas.read_csv(filename1, sep="\t")
+    df2 = pandas.read_csv(filename2, sep="\t")
+
+    # drop the text-y ones
+    df1.drop([fasttrips.Performance.PERFORMANCE_COLUMN_TIME_LABELING, fasttrips.Performance.PERFORMANCE_COLUMN_TIME_ENUMERATING], axis=1, inplace=True)
+    df2.drop([fasttrips.Performance.PERFORMANCE_COLUMN_TIME_LABELING, fasttrips.Performance.PERFORMANCE_COLUMN_TIME_ENUMERATING], axis=1, inplace=True)
+
+    df_perf_diff  = df1.merge(right=df2, how='outer', on=['iteration','trip_list_id_num'], suffixes=('_1','_2'))
+
+    # write the joined one
+    join_filename = os.path.join(dir1, "ft_compare_performance.csv")
+    df_perf_diff.to_csv(join_filename, sep=",", index=False)
+    FastTripsLogger.info("Wrote joined performance info to %s" % join_filename)
 
 if __name__ == "__main__":
 
@@ -260,3 +282,4 @@ if __name__ == "__main__":
         compare_file(OUTPUT_DIR1, OUTPUT_DIR2, output_file)
 
     compare_pathset(OUTPUT_DIR1, OUTPUT_DIR2)
+    compare_performance(OUTPUT_DIR1, OUTPUT_DIR2)

--- a/src/LabelStopQueue.h
+++ b/src/LabelStopQueue.h
@@ -1,3 +1,5 @@
+#include <cassert>
+#include <exception>
 
 namespace fasttrips {
 
@@ -21,44 +23,154 @@ namespace fasttrips {
         }
     };
 
+    class LabelStopQueueError : public std::runtime_error {
+    public:
+        LabelStopQueueError(const std::string& what_arg): std::runtime_error(what_arg) {}
+        LabelStopQueueError(const char* what_arg): std::runtime_error(what_arg) {}
+        virtual ~LabelStopQueueError() throw() {}
+    };
+
     /**
-     * This is just like a priority queue but with the additonal constraint that each stop can only be in the queue once.
+     * This is just like a priority queue but with the additonal constraint that each stop ID can only be in the queue once.
+     *
+     * This is to save work; if we mark a stop for processing by adding it onto the queue, and then do that again shortly
+     * after, we don't actually want to process twice.  We only want to process it once, for the lowest label.
+     *
      **/
     class LabelStopQueue
     {
 
     private:
-        /**
-         * The pathfinding algorithm uses this to find the lowest label stops. The LabelStopQueue will have the
-         *     latest departure time from a stop (outbound) and we want max, or
-         *   earliest arrival   time to   a stop (inbound ) and we want min
-         * Since it's a min priority queue, for outbound, we'll want to make it negative to get min
-         */
+        // underlying priority queue, contains (label, stop id)
         std::priority_queue<LabelStop, std::vector<LabelStop>, struct LabelStopCompare> labelstop_priority_queue_;
 
+        typedef struct {
+            double label_;  ///< lowest label for this stop in the labelstop_priority_queue_ (e.g. the only valid one)
+            bool   valid_;  ///< is this stop valid in the queue?
+            int    count_;  ///< number of instances of this stop in the labelstop_priority_queue_ (valid and invalid)
+        } LabelCount;
+
+        /** Keep track of the lowest label and the count for each stop */
+        std::map<int, LabelCount> labelstop_map_;
+
+        int valid_count_;
 
     public:
-        LabelStopQueue() {}
+        LabelStopQueue() : valid_count_(0) {}
         ~LabelStopQueue() {}
 
         void push(const LabelStop& val) {
-            labelstop_priority_queue_.push(val);
+            // if the stop is not in here, no problem!
+            if (labelstop_map_.find(val.stop_id_) == labelstop_map_.end()) {
+                labelstop_priority_queue_.push(val);
+                LabelCount lc = { val.label_, true, 1 };
+                labelstop_map_[val.stop_id_] = lc;
+                valid_count_++;
+                return;
+            }
+
+            // if not valid in the queue, then we've popped out all valid instances from the priority queue so it's like it's not here
+            if (!labelstop_map_[val.stop_id_].valid_) {
+                labelstop_priority_queue_.push(val);
+                labelstop_map_[val.stop_id_].label_     = val.label_;
+                labelstop_map_[val.stop_id_].valid_     = true;
+                labelstop_map_[val.stop_id_].count_    += 1;
+                valid_count_++;
+                return;
+            }
+
+            // The stop is in the queue, valid.  Look at the label.
+            // If the label is smaller, add this one and invalidate the other
+            if (val.label_ < labelstop_map_[val.stop_id_].label_) {
+                labelstop_priority_queue_.push(val);
+                labelstop_map_[val.stop_id_].label_ = val.label_;
+                labelstop_map_[val.stop_id_].count_ += 1;
+                // no additional valid counts
+            }
+            // otherwise the label is bigger -- don't add it since the smaller one will cause reprocessing
+            else {
+                // we're ok
+            }
         }
 
-        const LabelStop& top() const {
-            return labelstop_priority_queue_.top();
-        }
+        /** Pop the top *valid* LabelStop */
+        LabelStop pop_top(const std::map<int, std::string>& stop_num_to_str, bool trace, std::ofstream& trace_file) {
+            // this will crash if labelstop_priority_queue_ is empty.  I'm terrible.
 
-        void pop() {
-            labelstop_priority_queue_.pop();
+            while (true) {
+                // get the lowest cost stop
+                const LabelStop& ls = labelstop_priority_queue_.top();
+                std::map<int, LabelCount>::iterator ls_iter = labelstop_map_.find(ls.stop_id_);
+
+                // assert we have the count info
+                if (ls_iter == labelstop_map_.end()) {
+                    std::cerr << "LabelStopQueueError FATAL ERROR 1" << std::endl;
+                    throw LabelStopQueueError("FATAL ERROR 1");
+                }
+
+                // assert that the count is positive
+                if (ls_iter->second.count_ <= 0) {
+                    std::cerr << "LabelStopQueueError FATAL ERROR 2" << std::endl;
+                    throw LabelStopQueueError("FATAL ERROR 2");
+                }
+
+                // if it's not valid then continue
+                if (!ls_iter->second.valid_) {
+                    if (trace) {
+                        trace_file << "Skipping stop A " << stop_num_to_str.find(ls.stop_id_)->second;
+                        trace_file << "; valid " << ls_iter->second.valid_;
+                        trace_file << "; count " << ls_iter->second.count_;
+                        trace_file << "; map label " << ls_iter->second.label_;
+                        trace_file << "; priq label " << ls.label_;
+                        trace_file << "; priq size " << labelstop_priority_queue_.size() << std::endl;
+                    }
+                    ls_iter->second.count_ -= 1;
+                    labelstop_priority_queue_.pop();
+                    continue;
+                }
+
+                // this stop id is in the queue as valid
+                // but only the matching label is valid
+                if (ls_iter->second.label_ != ls.label_) {
+                    if (trace) {
+                        trace_file << "Skipping stop B " << stop_num_to_str.find(ls.stop_id_)->second;
+                        trace_file << "; valid " << ls_iter->second.valid_;
+                        trace_file << "; count " << ls_iter->second.count_;
+                        trace_file << "; map label " << ls_iter->second.label_;
+                        trace_file << "; priq label " << ls.label_;
+                        trace_file << "; priq size " << labelstop_priority_queue_.size() << std::endl;
+                    }
+                    ls_iter->second.count_ -= 1;
+                    labelstop_priority_queue_.pop();
+                    continue;
+                }
+
+                if (trace) {
+                    trace_file << "LabelStopQueue returning " << stop_num_to_str.find(ls.stop_id_)->second;
+                    trace_file << "; valid " << ls_iter->second.valid_;
+                    trace_file << "; count " << ls_iter->second.count_;
+                    trace_file << "; map label " << ls_iter->second.label_;
+                    trace_file << "; priq label " << ls.label_;
+                    trace_file << "; priq size " << labelstop_priority_queue_.size();
+                    trace_file << "; valid count " << valid_count_ << std::endl;
+                }
+                // else the map label is equal to the priority queue one, it's the valid one -- return it
+                LabelStop to_ret = ls;
+                labelstop_priority_queue_.pop();
+                ls_iter->second.valid_  = false; // not valid any longer
+                ls_iter->second.count_ -= 1;     // decrement count
+                valid_count_ -= 1;
+                return to_ret;
+
+            }
         }
 
         size_t size() const {
-            return labelstop_priority_queue_.size();
+            return valid_count_;
         }
 
         bool empty() const {
-            return labelstop_priority_queue_.empty();
+            return (valid_count_ == 0);
         }
     };
 

--- a/src/LabelStopQueue.h
+++ b/src/LabelStopQueue.h
@@ -1,0 +1,65 @@
+
+namespace fasttrips {
+
+    /**
+     * Struct containing just a label and a stop id, this is stored in the fasttrips::LabelStopQueue
+     * (a priority queue) to find the lowest label stops.
+     */
+    typedef struct {
+        double  label_;                 ///< The label during path finding
+        int     stop_id_;               ///< Stop ID corresponding to this label
+    } LabelStop;
+
+
+    /// Comparator to enable the fasttrips::LabelStopQueue to return the lowest labeled stop.
+    struct LabelStopCompare {
+        bool operator()(const LabelStop &cs1, const LabelStop &cs2) const {
+            if (cs1.label_ > cs2.label_) { return true;  }
+            if (cs1.label_ < cs2.label_) { return false; }
+            // if they're equal go by the stop id
+            return (cs1.stop_id_ > cs2.stop_id_);
+        }
+    };
+
+    /**
+     * This is just like a priority queue but with the additonal constraint that each stop can only be in the queue once.
+     **/
+    class LabelStopQueue
+    {
+
+    private:
+        /**
+         * The pathfinding algorithm uses this to find the lowest label stops. The LabelStopQueue will have the
+         *     latest departure time from a stop (outbound) and we want max, or
+         *   earliest arrival   time to   a stop (inbound ) and we want min
+         * Since it's a min priority queue, for outbound, we'll want to make it negative to get min
+         */
+        std::priority_queue<LabelStop, std::vector<LabelStop>, struct LabelStopCompare> labelstop_priority_queue_;
+
+
+    public:
+        LabelStopQueue() {}
+        ~LabelStopQueue() {}
+
+        void push(const LabelStop& val) {
+            labelstop_priority_queue_.push(val);
+        }
+
+        const LabelStop& top() const {
+            return labelstop_priority_queue_.top();
+        }
+
+        void pop() {
+            labelstop_priority_queue_.pop();
+        }
+
+        size_t size() const {
+            return labelstop_priority_queue_.size();
+        }
+
+        bool empty() const {
+            return labelstop_priority_queue_.empty();
+        }
+    };
+
+};

--- a/src/fasttrips.cpp
+++ b/src/fasttrips.cpp
@@ -19,10 +19,11 @@ _fasttrips_initialize_parameters(PyObject *self, PyObject *args)
     double     bump_buffer;
     int        stoch_pathset_size;
     double     stoch_dispersion;
-    if (!PyArg_ParseTuple(args, "ddid", &time_window, &bump_buffer, &stoch_pathset_size, &stoch_dispersion)) {
+    int        stoch_max_stop_process_count;
+    if (!PyArg_ParseTuple(args, "ddidi", &time_window, &bump_buffer, &stoch_pathset_size, &stoch_dispersion, &stoch_max_stop_process_count)) {
         return NULL;
     }
-    pathfinder.initializeParameters(time_window, bump_buffer, stoch_pathset_size, stoch_dispersion);
+    pathfinder.initializeParameters(time_window, bump_buffer, stoch_pathset_size, stoch_dispersion, stoch_max_stop_process_count);
     Py_RETURN_NONE;
 
 }

--- a/src/fasttrips.cpp
+++ b/src/fasttrips.cpp
@@ -116,7 +116,8 @@ _fasttrips_find_path(PyObject *self, PyObject *args)
 
     fasttrips::Path path;
     fasttrips::PathInfo path_info = {0, 0, false, 0, 0};
-    pathfinder.findPath(path_spec, path, path_info);
+    fasttrips::PerformanceInfo perf_info = { 0, 0, 0, 0};
+    pathfinder.findPath(path_spec, path, path_info, perf_info);
 
     // package for returning.  We'll separate ints and doubles.
     npy_intp dims_int[2];
@@ -144,7 +145,9 @@ _fasttrips_find_path(PyObject *self, PyObject *args)
         *(npy_double*)PyArray_GETPTR2(ret_double, ind, 4) = path[ind].second.arrdep_time_;
     }
 
-    PyObject *returnobj = Py_BuildValue("(OOd)",ret_int,ret_double,path_info.cost_);
+    PyObject *returnobj = Py_BuildValue("(OOdiill)",ret_int,ret_double,path_info.cost_,
+                                        perf_info.label_iterations_, perf_info.max_process_count_,
+                                        perf_info.milliseconds_labeling_, perf_info.milliseconds_enumerating_);
     return returnobj;
 }
 

--- a/src/fasttrips.cpp
+++ b/src/fasttrips.cpp
@@ -138,7 +138,7 @@ _fasttrips_find_path(PyObject *self, PyObject *args)
         *(npy_int32*)PyArray_GETPTR2(ret_int, ind, 4) = path.states_[stop_id].seq_;
         *(npy_int32*)PyArray_GETPTR2(ret_int, ind, 5) = path.states_[stop_id].seq_succpred_;
 
-        *(npy_double*)PyArray_GETPTR2(ret_double, ind, 0) = path.states_[stop_id].label_;
+        *(npy_double*)PyArray_GETPTR2(ret_double, ind, 0) = 0.0; // TODO: label
         *(npy_double*)PyArray_GETPTR2(ret_double, ind, 1) = path.states_[stop_id].deparr_time_;
         *(npy_double*)PyArray_GETPTR2(ret_double, ind, 2) = path.states_[stop_id].link_time_;
         *(npy_double*)PyArray_GETPTR2(ret_double, ind, 3) = path.states_[stop_id].cost_;

--- a/src/fasttrips.cpp
+++ b/src/fasttrips.cpp
@@ -137,7 +137,7 @@ _fasttrips_find_path(PyObject *self, PyObject *args)
         *(npy_int32*)PyArray_GETPTR2(ret_int, ind, 4) = path[ind].second.seq_;
         *(npy_int32*)PyArray_GETPTR2(ret_int, ind, 5) = path[ind].second.seq_succpred_;
 
-        *(npy_double*)PyArray_GETPTR2(ret_double, ind, 0) = path[ind].second.label_;
+        *(npy_double*)PyArray_GETPTR2(ret_double, ind, 0) = 0.0; // TODO: label
         *(npy_double*)PyArray_GETPTR2(ret_double, ind, 1) = path[ind].second.deparr_time_;
         *(npy_double*)PyArray_GETPTR2(ret_double, ind, 2) = path[ind].second.link_time_;
         *(npy_double*)PyArray_GETPTR2(ret_double, ind, 3) = path[ind].second.cost_;

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -540,6 +540,7 @@ namespace fasttrips {
                     hss.latest_dep_earliest_arr_ = ss.deparr_time_;
                     update_state = true;
                     trace_suffix += " (window)";
+                    ls.label_                    = hss.hyperpath_cost_;
                 }
 
                 // update stop cost if it's affected

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -924,7 +924,7 @@ namespace fasttrips {
 
         // current_stop_state is a vector
         std::vector<StopState>& current_stop_state = stop_states[current_label_stop.stop_id_];
-        int current_mode = current_stop_state[0].deparr_mode_;      // why index 0?
+        int current_mode = current_stop_state[0].deparr_mode_;      // why index 0 for hyperpath?-- should this be the latest_dep_earliest_arrival mode?
         double latest_dep_earliest_arr = current_stop_state[0].deparr_time_;
         if (path_spec.hyperpath_) {
             latest_dep_earliest_arr = hyperpath_ss[current_label_stop.stop_id_].latest_dep_earliest_arr_;

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -1825,7 +1825,6 @@ namespace fasttrips {
                 if (isTrip(path[index+inc].second.deparr_mode_)) {
                     int xfer_stop_id = path_spec.outbound_ ? stop_state.stop_succpred_ : stop_id;
                     StopState xfer_state = {
-                        stop_state.label_,     // label
                         path_spec.outbound_ ? stop_state.arrdep_time_ : stop_state.deparr_time_, // departure/arrival time
                         MODE_TRANSFER,         // mode
                         transfer_supply_mode_, // trip id

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -41,12 +41,14 @@ namespace fasttrips {
         double     time_window,
         double     bump_buffer,
         int        stoch_pathset_size,
-        double     stoch_dispersion)
+        double     stoch_dispersion,
+        int        stoch_max_stop_process_count)
     {
-        TIME_WINDOW_        = time_window;
-        BUMP_BUFFER_        = bump_buffer;
-        STOCH_PATHSET_SIZE_ = stoch_pathset_size;
-        STOCH_DISPERSION_   = stoch_dispersion;
+        TIME_WINDOW_                    = time_window;
+        BUMP_BUFFER_                    = bump_buffer;
+        STOCH_PATHSET_SIZE_             = stoch_pathset_size;
+        STOCH_DISPERSION_               = stoch_dispersion;
+        STOCH_MAX_STOP_PROCESS_COUNT_   = stoch_max_stop_process_count;
     }
 
     void PathFinder::readIntermediateFiles()
@@ -1230,6 +1232,14 @@ namespace fasttrips {
 
             // hyperpath only
             if (path_spec.hyperpath_) {
+                // have we hit the configured limit?
+                if ((STOCH_MAX_STOP_PROCESS_COUNT_ > 0) && (hyperpath_ss[current_label_stop.stop_id_].process_count_ == STOCH_MAX_STOP_PROCESS_COUNT_)) {
+                    if (path_spec.trace_) {
+                        trace_file << "Pulling from label_stop_queue but stop " << stop_num_to_str_.find(current_label_stop.stop_id_)->second;
+                        trace_file << " has been processed the limit " << STOCH_MAX_STOP_PROCESS_COUNT_ << " times so skipping." << std::endl;
+                    }
+                    continue;
+                }
                 // stop is processing
                 hyperpath_ss[current_label_stop.stop_id_].process_count_ += 1;
                 max_process_count = max(max_process_count, hyperpath_ss[current_label_stop.stop_id_].process_count_);

--- a/src/pathfinder.h
+++ b/src/pathfinder.h
@@ -4,6 +4,7 @@
  * Defines the C++ the finds a transit path for fast-trips.
  */
 
+#include <ctime>
 #include <map>
 #include <vector>
 #include <queue>
@@ -213,6 +214,14 @@ namespace fasttrips {
         int     prob_i_;                        ///< Cumulative probability * RAND_MAX (for stochastic)
     } PathInfo;
 
+    /** Performance information to return. */
+    typedef struct {
+        int     label_iterations_;              ///< Number of label iterations performed
+        int     max_process_count_;             ///< Maximum number of times a stop was processed
+        long    milliseconds_labeling_;         ///< Number of seconds spent in labeling
+        long    milliseconds_enumerating_;      ///< Number of seconds spent in enumerating
+    } PerformanceInfo;
+
     /// Comparator to for Path instances so we can put them in a map as keys.
     /// TODO: doc more?
     struct PathCompare {
@@ -381,7 +390,8 @@ namespace fasttrips {
                                   std::ofstream& trace_file,
                                   StopStates& stop_states,
                                   LabelStopQueue& label_stop_queue,
-                                  HyperpathStopStates& hyperpath_ss) const;
+                                  HyperpathStopStates& hyperpath_ss,
+                                  int& max_process_count) const;
 
         /**
          * This is like the reverse of PathFinder::initializeStopStates.
@@ -531,6 +541,7 @@ namespace fasttrips {
          */
         void findPath(PathSpecification path_spec,
                       Path              &path,
-                      PathInfo          &path_info) const;
+                      PathInfo          &path_info,
+                      PerformanceInfo   &performance_info) const;
     };
 }

--- a/src/pathfinder.h
+++ b/src/pathfinder.h
@@ -263,6 +263,13 @@ namespace fasttrips {
 
         /// See <a href="_generated/fasttrips.Assignment.html#fasttrips.Assignment.STOCH_DISPERSION">fasttrips.Assignment.STOCH_DISPERSION</a>
         double STOCH_DISPERSION_;
+
+        /// Minimum time required to transfer between two vehicles at the same stop
+        /// This comes up because in path labeling, we could label a bus that leaves at the same time another bus arrives
+        /// But during path enumeration, leaving at the same time didn't register as ok.  Need a small epsilon here, since transfers
+        /// are not actually instantaneous.
+        /// TODO: add to python?
+        double MIN_XFER_TIME_;
         ///@}
 
         /// directory in which to write trace files
@@ -335,10 +342,7 @@ namespace fasttrips {
                           const StopState& ss,
                           StopStates& stop_states,
                           LabelStopQueue& label_stop_queue,
-                          HyperpathStopStates& hyperpath_ss,
-                          const std::tr1::unordered_set<int>* stop_done,
-                          const std::tr1::unordered_set<int>* stop_processing,
-                          const LabelStop* current_label_stop) const;
+                          HyperpathStopStates& hyperpath_ss) const;
 
         /**
          * Initialize the stop states from the access (for inbound) or egress (for outbound) links
@@ -363,9 +367,7 @@ namespace fasttrips {
                                   LabelStopQueue& label_stop_queue,
                                   HyperpathStopStates& hyperpath_ss,
                                   int label_iteration,
-                                  const LabelStop& current_label_stop,
-                                  const std::tr1::unordered_set<int>& stop_done,
-                                  const std::tr1::unordered_set<int>& stop_processing) const;
+                                  const LabelStop& current_label_stop) const;
 
         /**
          * Iterate through all the stops that are accessible by transit vehicle trip
@@ -380,9 +382,7 @@ namespace fasttrips {
                                   HyperpathStopStates& hyperpath_ss,
                                   int label_iteration,
                                   const LabelStop& current_label_stop,
-                                  std::tr1::unordered_set<int>& trips_done,
-                                  const std::tr1::unordered_set<int>& stop_done,
-                                  const std::tr1::unordered_set<int>& stop_processing) const;
+                                  std::tr1::unordered_set<int>& trips_done) const;
 
         /**
          * Label stops by:

--- a/src/pathfinder.h
+++ b/src/pathfinder.h
@@ -201,6 +201,7 @@ namespace fasttrips {
     typedef struct {
       double latest_dep_earliest_arr_; ///< latest departure time from this stop for outbound trips, earliest arrival time to this stop for inbound trips
       double hyperpath_cost_;          ///< hyperpath cost for this stop state
+      int    process_count_;           ///< increment this every time the stop is processed
     } HyperpathState;
 
     /**
@@ -386,7 +387,6 @@ namespace fasttrips {
                                   HyperpathStopStates& hyperpath_ss,
                                   int label_iteration,
                                   const LabelStop& current_label_stop,
-                                  double latest_dep_earliest_arr,
                                   const std::tr1::unordered_set<int>& stop_done,
                                   const std::tr1::unordered_set<int>& stop_processing) const;
 
@@ -403,7 +403,6 @@ namespace fasttrips {
                                   HyperpathStopStates& hyperpath_ss,
                                   int label_iteration,
                                   const LabelStop& current_label_stop,
-                                  double latest_dep_earliest_arr,
                                   std::tr1::unordered_set<int>& trips_done,
                                   const std::tr1::unordered_set<int>& stop_done,
                                   const std::tr1::unordered_set<int>& stop_processing) const;

--- a/src/pathfinder.h
+++ b/src/pathfinder.h
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include "LabelStopQueue.h"
 
 #if __APPLE__
 #include <tr1/unordered_set>
@@ -161,14 +162,6 @@ namespace fasttrips {
         double  arrdep_time_;           ///< Arrival time for outbound, departure time for inbound
     } StopState;
 
-    /**
-     * Struct containing just a label and a stop id, this is stored in the fasttrips::LabelStopQueue
-     * (a priority queue) to find the lowest label stops.
-     */
-    typedef struct {
-        double  label_;                 ///< The label during path finding
-        int     stop_id_;               ///< Stop ID corresponding to this label
-    } LabelStop;
 
     /// Structure used in PathFinder::hyperpathChoosePath
     typedef struct {
@@ -177,16 +170,6 @@ namespace fasttrips {
         int     stop_id_;               ///< Stop ID
         size_t  index_;                 ///< Index into StopState vector (or taz state vector)
     } ProbabilityStop;
-
-    /// Comparator to enable the fasttrips::LabelStopQueue to return the lowest labeled stop.
-    struct LabelStopCompare {
-        bool operator()(const LabelStop &cs1, const LabelStop &cs2) const {
-            if (cs1.label_ > cs2.label_) { return true;  }
-            if (cs1.label_ < cs2.label_) { return false; }
-            // if they're equal go by the stop id
-            return (cs1.stop_id_ > cs2.stop_id_);
-        }
-    };
 
     /**
      * The path finding algorithm stores StopState data in this structure.
@@ -213,13 +196,7 @@ namespace fasttrips {
      */
      typedef std::map<int, HyperpathState> HyperpathStopStates;
 
-    /**
-     * The pathfinding algorithm uses this to find the lowest label stops. The LabelStopQueue will have the
-     *     latest departure time from a stop (outbound) and we want max, or
-     *   earliest arrival   time to   a stop (inbound ) and we want min
-     * Since it's a min priority queue, for outbound, we'll want to make it negative to get min
-     */
-    typedef std::priority_queue<LabelStop, std::vector<LabelStop>, struct LabelStopCompare> LabelStopQueue;
+
 
     /** A single path consists of a map of stop id to StopState, plus the order of the stops are given
      *  a list of stop ids.

--- a/src/pathfinder.h
+++ b/src/pathfinder.h
@@ -183,6 +183,7 @@ namespace fasttrips {
     **/
     typedef struct {
       double latest_dep_earliest_arr_; ///< latest departure time from this stop for outbound trips, earliest arrival time to this stop for inbound trips
+      int    lder_trip_id_;            ///< trip for the latest departure/earliest arrival
       double hyperpath_cost_;          ///< hyperpath cost for this stop state
       int    process_count_;           ///< increment this every time the stop is processed
     } HyperpathState;
@@ -255,13 +256,6 @@ namespace fasttrips {
 
         /// See <a href="_generated/fasttrips.Assignment.html#fasttrips.Assignment.STOCH_DISPERSION">fasttrips.Assignment.STOCH_DISPERSION</a>
         double STOCH_DISPERSION_;
-
-        /// Minimum time required to transfer between two vehicles at the same stop
-        /// This comes up because in path labeling, we could label a bus that leaves at the same time another bus arrives
-        /// But during path enumeration, leaving at the same time didn't register as ok.  Need a small epsilon here, since transfers
-        /// are not actually instantaneous.
-        /// TODO: add to python?
-        double MIN_XFER_TIME_;
         ///@}
 
         /// directory in which to write trace files

--- a/src/pathfinder.h
+++ b/src/pathfinder.h
@@ -265,6 +265,9 @@ namespace fasttrips {
 
         /// See <a href="_generated/fasttrips.Assignment.html#fasttrips.Assignment.STOCH_DISPERSION">fasttrips.Assignment.STOCH_DISPERSION</a>
         double STOCH_DISPERSION_;
+
+        /// See <a href="_generated/fasttrips.Assignment.html#fasttrips.Assignment.STOCH_MAX_STOP_PROCESS_COUNT">fasttrips.Assignment.STOCH_MAX_STOP_PROCESS_COUNT</a>
+        int STOCH_MAX_STOP_PROCESS_COUNT_;
         ///@}
 
         /// directory in which to write trace files
@@ -493,7 +496,8 @@ namespace fasttrips {
         void initializeParameters(double     time_window,
                                   double     bump_buffer,
                                   int        stoch_pathset_size,
-                                  double     stoch_dispersion);
+                                  double     stoch_dispersion,
+                                  int        stoch_max_stop_process_count);
 
         /**
          * Setup the network supply.  This should happen once, before any pathfinding.

--- a/tableau/CompareResultsAndPerformance.twb
+++ b/tableau/CompareResultsAndPerformance.twb
@@ -1,0 +1,1488 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<!-- build 9200.16.0303.2316                                -->
+<workbook source-platform='win' version='9.2' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <preferences>
+    <preference name='ui.encoding.shelf.height' value='24' />
+    <preference name='ui.shelf.height' value='26' />
+  </preferences>
+  <datasources>
+    <datasource hasconnection='false' inline='true' name='Parameters' version='9.2'>
+      <aliases enabled='yes' />
+      <column caption='label time bin_size' datatype='integer' name='[Parameter 1]' param-domain-type='any' role='measure' type='quantitative' value='100'>
+        <calculation class='tableau' formula='100' />
+      </column>
+      <column caption='label iter bin_size' datatype='integer' name='[label time bin_size (copy)]' param-domain-type='any' role='measure' type='quantitative' value='100'>
+        <calculation class='tableau' formula='100' />
+      </column>
+    </datasource>
+    <datasource caption='ft_compare_performance+' inline='true' name='textscan.0wftuej14f4jy416a0ad50fgrmp7' version='9.2'>
+      <connection class='textscan' directory='C:/Users/lzorn/Documents/fast-trips-stop_order/sfcta/demand_v0.1_maxstopproc1_stochastic_iter1_nocap' filename='ft_compare_performance.csv' password='' server='' username=''>
+        <relation join='inner' type='join'>
+          <clause type='join'>
+            <expression op='AND'>
+              <expression op='='>
+                <expression op='[ft_compare_performance#csv].[iteration]' />
+                <expression op='[ft_compare_pathset#csv].[iteration]' />
+              </expression>
+              <expression op='='>
+                <expression op='[ft_compare_performance#csv].[trip_list_id_num]' />
+                <expression op='[ft_compare_pathset#csv].[trip_list_id_num]' />
+              </expression>
+            </expression>
+          </clause>
+          <relation name='ft_compare_performance#csv' table='[ft_compare_performance#csv]' type='table'>
+            <columns character-set='UTF-8' header='yes' locale='en_US' separator=','>
+              <column datatype='real' name='iteration' ordinal='0' />
+              <column datatype='real' name='trip_list_id_num' ordinal='1' />
+              <column datatype='real' name='label iterations_1' ordinal='2' />
+              <column datatype='real' name='max stop process count_1' ordinal='3' />
+              <column datatype='real' name='time enumerating milliseconds_1' ordinal='4' />
+              <column datatype='real' name='time labeling milliseconds_1' ordinal='5' />
+              <column datatype='real' name='traced_1' ordinal='6' />
+              <column datatype='real' name='label iterations_2' ordinal='7' />
+              <column datatype='real' name='max stop process count_2' ordinal='8' />
+              <column datatype='real' name='time enumerating milliseconds_2' ordinal='9' />
+              <column datatype='real' name='time labeling milliseconds_2' ordinal='10' />
+              <column datatype='real' name='traced_2' ordinal='11' />
+            </columns>
+          </relation>
+          <relation name='ft_compare_pathset#csv' table='[ft_compare_pathset#csv]' type='table'>
+            <columns character-set='UTF-8' header='yes' locale='en_US' separator=','>
+              <column datatype='real' name='iteration' ordinal='0' />
+              <column datatype='real' name='passenger_id_num' ordinal='1' />
+              <column datatype='real' name='trip_list_id_num' ordinal='2' />
+              <column datatype='integer' name='num total paths' ordinal='3' />
+              <column datatype='real' name='num paths missing from file2' ordinal='4' />
+              <column datatype='real' name='max prob missing from file2' ordinal='5' />
+              <column datatype='real' name='max prob missing from file1' ordinal='6' />
+              <column datatype='real' name='num paths missing from file1' ordinal='7' />
+              <column datatype='integer' name='only in file1' ordinal='8' />
+              <column datatype='integer' name='only in file2' ordinal='9' />
+            </columns>
+          </relation>
+        </relation>
+        <cols>
+          <map key='[iteration (ft_compare_pathset.csv)]' value='[ft_compare_pathset#csv].[iteration]' />
+          <map key='[iteration]' value='[ft_compare_performance#csv].[iteration]' />
+          <map key='[label iterations_1]' value='[ft_compare_performance#csv].[label iterations_1]' />
+          <map key='[label iterations_2]' value='[ft_compare_performance#csv].[label iterations_2]' />
+          <map key='[max prob missing from file1]' value='[ft_compare_pathset#csv].[max prob missing from file1]' />
+          <map key='[max prob missing from file2]' value='[ft_compare_pathset#csv].[max prob missing from file2]' />
+          <map key='[max stop process count_1]' value='[ft_compare_performance#csv].[max stop process count_1]' />
+          <map key='[max stop process count_2]' value='[ft_compare_performance#csv].[max stop process count_2]' />
+          <map key='[num paths missing from file1]' value='[ft_compare_pathset#csv].[num paths missing from file1]' />
+          <map key='[num paths missing from file2]' value='[ft_compare_pathset#csv].[num paths missing from file2]' />
+          <map key='[num total paths]' value='[ft_compare_pathset#csv].[num total paths]' />
+          <map key='[only in file1]' value='[ft_compare_pathset#csv].[only in file1]' />
+          <map key='[only in file2]' value='[ft_compare_pathset#csv].[only in file2]' />
+          <map key='[passenger_id_num]' value='[ft_compare_pathset#csv].[passenger_id_num]' />
+          <map key='[time enumerating milliseconds_1]' value='[ft_compare_performance#csv].[time enumerating milliseconds_1]' />
+          <map key='[time enumerating milliseconds_2]' value='[ft_compare_performance#csv].[time enumerating milliseconds_2]' />
+          <map key='[time labeling milliseconds_1]' value='[ft_compare_performance#csv].[time labeling milliseconds_1]' />
+          <map key='[time labeling milliseconds_2]' value='[ft_compare_performance#csv].[time labeling milliseconds_2]' />
+          <map key='[traced_1]' value='[ft_compare_performance#csv].[traced_1]' />
+          <map key='[traced_2]' value='[ft_compare_performance#csv].[traced_2]' />
+          <map key='[trip_list_id_num (ft_compare_pathset.csv)]' value='[ft_compare_pathset#csv].[trip_list_id_num]' />
+          <map key='[trip_list_id_num]' value='[ft_compare_performance#csv].[trip_list_id_num]' />
+        </cols>
+        <metadata-records>
+          <metadata-record class='column'>
+            <remote-name>iteration</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[iteration]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>iteration</remote-alias>
+            <ordinal>0</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>trip_list_id_num</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[trip_list_id_num]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>trip_list_id_num</remote-alias>
+            <ordinal>1</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>label iterations_1</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[label iterations_1]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>label iterations_1</remote-alias>
+            <ordinal>2</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>max stop process count_1</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[max stop process count_1]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>max stop process count_1</remote-alias>
+            <ordinal>3</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>time enumerating milliseconds_1</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[time enumerating milliseconds_1]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>time enumerating milliseconds_1</remote-alias>
+            <ordinal>4</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>time labeling milliseconds_1</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[time labeling milliseconds_1]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>time labeling milliseconds_1</remote-alias>
+            <ordinal>5</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>traced_1</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[traced_1]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>traced_1</remote-alias>
+            <ordinal>6</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>label iterations_2</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[label iterations_2]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>label iterations_2</remote-alias>
+            <ordinal>7</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>max stop process count_2</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[max stop process count_2]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>max stop process count_2</remote-alias>
+            <ordinal>8</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>time enumerating milliseconds_2</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[time enumerating milliseconds_2]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>time enumerating milliseconds_2</remote-alias>
+            <ordinal>9</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>time labeling milliseconds_2</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[time labeling milliseconds_2]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>time labeling milliseconds_2</remote-alias>
+            <ordinal>10</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>traced_2</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[traced_2]</local-name>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias>traced_2</remote-alias>
+            <ordinal>11</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='capability'>
+            <remote-name />
+            <remote-type>0</remote-type>
+            <parent-name>[ft_compare_performance#csv]</parent-name>
+            <remote-alias />
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='character-set'>&quot;UTF-8&quot;</attribute>
+              <attribute datatype='string' name='collation'>&quot;en_US&quot;</attribute>
+              <attribute datatype='string' name='field-delimiter'>&quot;,&quot;</attribute>
+              <attribute datatype='string' name='header-row'>&quot;true&quot;</attribute>
+              <attribute datatype='string' name='locale'>&quot;en_US&quot;</attribute>
+              <attribute datatype='string' name='single-char'>&quot;&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>iteration</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[iteration (ft_compare_pathset.csv)]</local-name>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias>iteration</remote-alias>
+            <ordinal>12</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>passenger_id_num</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[passenger_id_num]</local-name>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias>passenger_id_num</remote-alias>
+            <ordinal>13</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>trip_list_id_num</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[trip_list_id_num (ft_compare_pathset.csv)]</local-name>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias>trip_list_id_num</remote-alias>
+            <ordinal>14</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>num total paths</remote-name>
+            <remote-type>20</remote-type>
+            <local-name>[num total paths]</local-name>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias>num total paths</remote-alias>
+            <ordinal>15</ordinal>
+            <local-type>integer</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;sint64&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>num paths missing from file2</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[num paths missing from file2]</local-name>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias>num paths missing from file2</remote-alias>
+            <ordinal>16</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>max prob missing from file2</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[max prob missing from file2]</local-name>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias>max prob missing from file2</remote-alias>
+            <ordinal>17</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>max prob missing from file1</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[max prob missing from file1]</local-name>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias>max prob missing from file1</remote-alias>
+            <ordinal>18</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>num paths missing from file1</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[num paths missing from file1]</local-name>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias>num paths missing from file1</remote-alias>
+            <ordinal>19</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>only in file1</remote-name>
+            <remote-type>20</remote-type>
+            <local-name>[only in file1]</local-name>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias>only in file1</remote-alias>
+            <ordinal>20</ordinal>
+            <local-type>integer</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;sint64&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>only in file2</remote-name>
+            <remote-type>20</remote-type>
+            <local-name>[only in file2]</local-name>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias>only in file2</remote-alias>
+            <ordinal>21</ordinal>
+            <local-type>integer</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;sint64&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='capability'>
+            <remote-name />
+            <remote-type>0</remote-type>
+            <parent-name>[ft_compare_pathset#csv]</parent-name>
+            <remote-alias />
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='character-set'>&quot;UTF-8&quot;</attribute>
+              <attribute datatype='string' name='collation'>&quot;en_US&quot;</attribute>
+              <attribute datatype='string' name='field-delimiter'>&quot;,&quot;</attribute>
+              <attribute datatype='string' name='header-row'>&quot;true&quot;</attribute>
+              <attribute datatype='string' name='locale'>&quot;en_US&quot;</attribute>
+              <attribute datatype='string' name='single-char'>&quot;&quot;</attribute>
+            </attributes>
+          </metadata-record>
+        </metadata-records>
+      </connection>
+      <aliases enabled='yes' />
+      <column aggregation='Sum' caption='Label Time 1 binned' datatype='integer' name='[Calculation_714946504221208578]' role='dimension' type='quantitative'>
+        <calculation class='tableau' formula='Floor([time labeling milliseconds_1]/[Parameters].[Parameter 1])*[Parameters].[Parameter 1]' />
+      </column>
+      <column aggregation='Sum' caption='Label Time 2 binned' datatype='integer' name='[Calculation_714946504221356035]' role='dimension' type='quantitative'>
+        <calculation class='tableau' formula='Floor([time labeling milliseconds_2]/[Parameters].[Parameter 1])*[Parameters].[Parameter 1]' />
+      </column>
+      <column aggregation='Sum' caption='Label Iter 1 binned' datatype='integer' name='[Calculation_714946504231649286]' role='dimension' type='quantitative'>
+        <calculation class='tableau' formula='Floor([label iterations_1]/[Parameters].[label time bin_size (copy)])*[Parameters].[label time bin_size (copy)]' />
+      </column>
+      <column caption='Problematic Missing Path' datatype='string' name='[Calculation_714946504234672136]' role='dimension' type='nominal'>
+        <calculation class='tableau' formula='IF ([max prob missing from file1] &gt; 0.05) THEN&#13;&#10;  &apos;TRUE&apos;&#13;&#10;ELSEIF ([max prob missing from file2] &gt; 0.05) THEN&#13;&#10;  &apos;TRUE&apos;&#13;&#10;ELSE&#13;&#10;  &apos;FALSE&apos;&#13;&#10;END' />
+      </column>
+      <column aggregation='Sum' caption='Label Iter 2 binned' datatype='integer' name='[Label Iter 1 binned (copy)]' role='dimension' type='quantitative'>
+        <calculation class='tableau' formula='Floor([label iterations_2]/[Parameters].[label time bin_size (copy)])*[Parameters].[label time bin_size (copy)]' />
+      </column>
+      <column datatype='integer' name='[Number of Records (bin)]' role='dimension' type='ordinal'>
+        <calculation class='bin' decimals='0' formula='[Number of Records]' peg='0' size='1' />
+      </column>
+      <column datatype='integer' name='[Number of Records]' role='measure' type='quantitative' user:auto-column='numrec'>
+        <calculation class='tableau' formula='1' />
+      </column>
+      <column aggregation='Sum' caption='Iteration (Ft Compare Pathset.Csv)' datatype='real' name='[iteration (ft_compare_pathset.csv)]' role='dimension' type='ordinal' />
+      <column aggregation='Sum' caption='Iteration' datatype='real' name='[iteration]' role='dimension' type='ordinal' />
+      <column caption='Label Iterations 1' datatype='real' name='[label iterations_1]' role='measure' type='quantitative' />
+      <column caption='Label Iterations 2' datatype='real' name='[label iterations_2]' role='measure' type='quantitative' />
+      <column caption='Max Prob Missing From File1' datatype='real' name='[max prob missing from file1]' role='measure' type='quantitative' />
+      <column caption='Max Prob Missing From File2' datatype='real' name='[max prob missing from file2]' role='measure' type='quantitative' />
+      <column caption='Max Stop Process Count 1' datatype='real' name='[max stop process count_1]' role='measure' type='quantitative' />
+      <column caption='Max Stop Process Count 2' datatype='real' name='[max stop process count_2]' role='measure' type='quantitative' />
+      <column caption='Num Paths Missing From File1' datatype='real' name='[num paths missing from file1]' role='measure' type='quantitative' />
+      <column caption='Num Paths Missing From File2' datatype='real' name='[num paths missing from file2]' role='measure' type='quantitative' />
+      <column caption='Num Total Paths' datatype='integer' name='[num total paths]' role='measure' type='quantitative' />
+      <column caption='Only In File1' datatype='integer' name='[only in file1]' role='measure' type='quantitative' />
+      <column caption='Only In File2' datatype='integer' name='[only in file2]' role='measure' type='quantitative' />
+      <column caption='Passenger Id Num' datatype='real' name='[passenger_id_num]' role='dimension' type='ordinal' />
+      <column caption='Time Enumerating Milliseconds 1' datatype='real' name='[time enumerating milliseconds_1]' role='measure' type='quantitative' />
+      <column caption='Time Enumerating Milliseconds 2' datatype='real' name='[time enumerating milliseconds_2]' role='measure' type='quantitative' />
+      <column caption='Time Labeling Milliseconds 1' datatype='real' name='[time labeling milliseconds_1]' role='measure' type='quantitative' />
+      <column caption='Time Labeling Milliseconds 2' datatype='real' name='[time labeling milliseconds_2]' role='measure' type='quantitative' />
+      <column aggregation='Sum' caption='Traced 1' datatype='real' name='[traced_1]' role='dimension' type='ordinal' />
+      <column aggregation='Sum' caption='Traced 2' datatype='real' name='[traced_2]' role='dimension' type='ordinal' />
+      <column caption='Trip List Id Num (Ft Compare Pathset.Csv)' datatype='real' name='[trip_list_id_num (ft_compare_pathset.csv)]' role='dimension' type='ordinal' />
+      <column caption='Trip List Id Num' datatype='real' name='[trip_list_id_num]' role='dimension' type='ordinal' />
+      <column-instance column='[max prob missing from file1]' derivation='Attribute' name='[attr:max prob missing from file1:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[max prob missing from file2]' derivation='Attribute' name='[attr:max prob missing from file2:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[time enumerating milliseconds_2]' derivation='Count' name='[cnt:time enumerating milliseconds_2:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[time labeling milliseconds_1]' derivation='Count' name='[cnt:time labeling milliseconds_1:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[time labeling milliseconds_2]' derivation='Count' name='[cnt:time labeling milliseconds_2:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[Number of Records]' derivation='Sum' name='[sum:Number of Records:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[max prob missing from file1]' derivation='Sum' name='[sum:max prob missing from file1:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[max prob missing from file2]' derivation='Sum' name='[sum:max prob missing from file2:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[time labeling milliseconds_2]' derivation='Sum' name='[sum:time labeling milliseconds_2:qk]' pivot='key' type='quantitative' />
+      <layout dim-ordering='alphabetic' dim-percentage='0.428363' measure-ordering='alphabetic' measure-percentage='0.52193' parameter-percentage='0.0497076' show-structure='true' />
+      <style>
+        <style-rule element='mark'>
+          <encoding attr='color' field='[:Measure Names]' type='palette'>
+            <map to='#1f77b4'>
+              <bucket>&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[cnt:time enumerating milliseconds_2:qk]&quot;</bucket>
+            </map>
+            <map to='#1f77b4'>
+              <bucket>&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[cnt:time labeling milliseconds_2:qk]&quot;</bucket>
+            </map>
+            <map to='#1f77b4'>
+              <bucket>&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[sum:time labeling milliseconds_2:qk]&quot;</bucket>
+            </map>
+            <map to='#2ca02c'>
+              <bucket>&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7]&quot;</bucket>
+            </map>
+            <map to='#8c564b'>
+              <bucket>&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[attr:max prob missing from file2:qk]&quot;</bucket>
+            </map>
+            <map to='#8c564b'>
+              <bucket>&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[sum:max prob missing from file2:qk]&quot;</bucket>
+            </map>
+            <map to='#9467bd'>
+              <bucket>&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[attr:max prob missing from file1:qk]&quot;</bucket>
+            </map>
+            <map to='#9467bd'>
+              <bucket>&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[sum:max prob missing from file1:qk]&quot;</bucket>
+            </map>
+            <map to='#d62728'>
+              <bucket>&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[sum:Number of Records:qk]&quot;</bucket>
+            </map>
+            <map to='#ff7f0e'>
+              <bucket>&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[cnt:time labeling milliseconds_1:qk]&quot;</bucket>
+            </map>
+          </encoding>
+        </style-rule>
+      </style>
+      <semantic-values>
+        <semantic-value key='[Country].[Name]' value='&quot;United States&quot;' />
+      </semantic-values>
+      <datasource-dependencies datasource='Parameters'>
+        <column caption='label time bin_size' datatype='integer' name='[Parameter 1]' param-domain-type='any' role='measure' type='quantitative' value='100'>
+          <calculation class='tableau' formula='100' />
+        </column>
+        <column caption='label iter bin_size' datatype='integer' name='[label time bin_size (copy)]' param-domain-type='any' role='measure' type='quantitative' value='100'>
+          <calculation class='tableau' formula='100' />
+        </column>
+      </datasource-dependencies>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Label Iterations'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='ft_compare_performance+' name='textscan.0wftuej14f4jy416a0ad50fgrmp7' />
+            <datasource name='Parameters' />
+          </datasources>
+          <datasource-dependencies datasource='Parameters'>
+            <column caption='label iter bin_size' datatype='integer' name='[label time bin_size (copy)]' param-domain-type='any' role='measure' type='quantitative' value='100'>
+              <calculation class='tableau' formula='100' />
+            </column>
+          </datasource-dependencies>
+          <datasource-dependencies datasource='textscan.0wftuej14f4jy416a0ad50fgrmp7'>
+            <column aggregation='Sum' caption='Label Iter 1 binned' datatype='integer' name='[Calculation_714946504231649286]' role='dimension' type='quantitative'>
+              <calculation class='tableau' formula='Floor([label iterations_1]/[Parameters].[label time bin_size (copy)])*[Parameters].[label time bin_size (copy)]' />
+            </column>
+            <column aggregation='Sum' caption='Label Iter 2 binned' datatype='integer' name='[Label Iter 1 binned (copy)]' role='dimension' type='quantitative'>
+              <calculation class='tableau' formula='Floor([label iterations_2]/[Parameters].[label time bin_size (copy)])*[Parameters].[label time bin_size (copy)]' />
+            </column>
+            <column datatype='integer' name='[Number of Records (bin)]' role='dimension' type='ordinal'>
+              <calculation class='bin' decimals='0' formula='[Number of Records]' peg='0' size='1' />
+            </column>
+            <column datatype='integer' name='[Number of Records]' role='measure' type='quantitative' user:auto-column='numrec'>
+              <calculation class='tableau' formula='1' />
+            </column>
+            <column caption='Label Iterations 1' datatype='real' name='[label iterations_1]' role='measure' type='quantitative' />
+            <column caption='Label Iterations 2' datatype='real' name='[label iterations_2]' role='measure' type='quantitative' />
+            <column-instance column='[Calculation_714946504231649286]' derivation='None' name='[none:Calculation_714946504231649286:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Label Iter 1 binned (copy)]' derivation='None' name='[none:Label Iter 1 binned (copy):qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Number of Records]' derivation='Sum' name='[sum:Number of Records:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='axis'>
+            <encoding attr='space' class='0' field='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Label Iter 1 binned (copy):qk]' field-type='quantitative' fold='true' scope='cols' synchronized='true' type='space' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Area' />
+          </pane>
+          <pane id='1' x-axis-name='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504231649286:qk]'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Area' />
+            <encodings>
+              <color column='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[Number of Records (bin)]' />
+            </encodings>
+          </pane>
+          <pane id='2' x-axis-name='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Label Iter 1 binned (copy):qk]'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Area' />
+          </pane>
+        </panes>
+        <rows>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[sum:Number of Records:qk]</rows>
+        <cols>([textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504231649286:qk] + [textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Label Iter 1 binned (copy):qk])</cols>
+      </table>
+    </worksheet>
+    <worksheet name='Label Times'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='ft_compare_performance+' name='textscan.0wftuej14f4jy416a0ad50fgrmp7' />
+            <datasource name='Parameters' />
+          </datasources>
+          <datasource-dependencies datasource='Parameters'>
+            <column caption='label time bin_size' datatype='integer' name='[Parameter 1]' param-domain-type='any' role='measure' type='quantitative' value='100'>
+              <calculation class='tableau' formula='100' />
+            </column>
+          </datasource-dependencies>
+          <datasource-dependencies datasource='textscan.0wftuej14f4jy416a0ad50fgrmp7'>
+            <column aggregation='Sum' caption='Label Time 1 binned' datatype='integer' name='[Calculation_714946504221208578]' role='dimension' type='quantitative'>
+              <calculation class='tableau' formula='Floor([time labeling milliseconds_1]/[Parameters].[Parameter 1])*[Parameters].[Parameter 1]' />
+            </column>
+            <column aggregation='Sum' caption='Label Time 2 binned' datatype='integer' name='[Calculation_714946504221356035]' role='dimension' type='quantitative'>
+              <calculation class='tableau' formula='Floor([time labeling milliseconds_2]/[Parameters].[Parameter 1])*[Parameters].[Parameter 1]' />
+            </column>
+            <column datatype='integer' name='[Number of Records (bin)]' role='dimension' type='ordinal'>
+              <calculation class='bin' decimals='0' formula='[Number of Records]' peg='0' size='1' />
+            </column>
+            <column datatype='integer' name='[Number of Records]' role='measure' type='quantitative' user:auto-column='numrec'>
+              <calculation class='tableau' formula='1' />
+            </column>
+            <column-instance column='[Calculation_714946504221208578]' derivation='None' name='[none:Calculation_714946504221208578:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Calculation_714946504221356035]' derivation='None' name='[none:Calculation_714946504221356035:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[traced_1]' derivation='None' name='[none:traced_1:ok]' pivot='key' type='ordinal' />
+            <column-instance column='[traced_2]' derivation='None' name='[none:traced_2:ok]' pivot='key' type='ordinal' />
+            <column-instance column='[Number of Records]' derivation='Sum' name='[sum:Number of Records:qk]' pivot='key' type='quantitative' />
+            <column caption='Time Labeling Milliseconds 1' datatype='real' name='[time labeling milliseconds_1]' role='measure' type='quantitative' />
+            <column caption='Time Labeling Milliseconds 2' datatype='real' name='[time labeling milliseconds_2]' role='measure' type='quantitative' />
+            <column aggregation='Sum' caption='Traced 1' datatype='real' name='[traced_1]' role='dimension' type='ordinal' />
+            <column aggregation='Sum' caption='Traced 2' datatype='real' name='[traced_2]' role='dimension' type='ordinal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:traced_1:ok]'>
+            <groupfilter function='member' level='[none:traced_1:ok]' member='0.0' user:ui-domain='database' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />
+          </filter>
+          <filter class='categorical' column='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:traced_2:ok]'>
+            <groupfilter function='member' level='[none:traced_2:ok]' member='0.0' user:ui-domain='database' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />
+          </filter>
+          <slices>
+            <column>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:traced_1:ok]</column>
+            <column>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:traced_2:ok]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='axis'>
+            <encoding attr='space' class='0' field='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221356035:qk]' field-type='quantitative' fold='true' scope='cols' synchronized='true' type='space' />
+            <encoding attr='space' class='0' field='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221208578:qk]' field-type='quantitative' max='10000' min='0' range-type='fixed' scope='cols' type='space' />
+            <format attr='subtitle' class='0' field='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221208578:qk]' scope='cols' value='' />
+            <format attr='auto-subtitle' class='0' field='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221208578:qk]' scope='cols' value='true' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Area' />
+          </pane>
+          <pane id='1' x-axis-name='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221208578:qk]'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Area' />
+            <encodings>
+              <color column='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[Number of Records (bin)]' />
+            </encodings>
+          </pane>
+          <pane id='2' x-axis-name='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221356035:qk]'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Area' />
+          </pane>
+        </panes>
+        <rows>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[sum:Number of Records:qk]</rows>
+        <cols>([textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221208578:qk] + [textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221356035:qk])</cols>
+      </table>
+    </worksheet>
+    <worksheet name='Max Stop Process Count'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='ft_compare_performance+' name='textscan.0wftuej14f4jy416a0ad50fgrmp7' />
+          </datasources>
+          <datasource-dependencies datasource='textscan.0wftuej14f4jy416a0ad50fgrmp7'>
+            <column-instance column='[max stop process count_1]' derivation='Avg' name='[avg:max stop process count_1:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[max stop process count_2]' derivation='Avg' name='[avg:max stop process count_2:qk]' pivot='key' type='quantitative' />
+            <column caption='Max Stop Process Count 1' datatype='real' name='[max stop process count_1]' role='measure' type='quantitative' />
+            <column caption='Max Stop Process Count 2' datatype='real' name='[max stop process count_2]' role='measure' type='quantitative' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]'>
+            <groupfilter function='union' user:op='manual'>
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[avg:max stop process count_1:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[avg:max stop process count_2:qk]&quot;' />
+            </groupfilter>
+          </filter>
+          <slices>
+            <column>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='header'>
+            <format attr='width' field='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]' value='196' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <text column='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[Multiple Values]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='true' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]</rows>
+        <cols />
+      </table>
+    </worksheet>
+    <worksheet name='Missing Paths'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='ft_compare_performance+' name='textscan.0wftuej14f4jy416a0ad50fgrmp7' />
+          </datasources>
+          <datasource-dependencies datasource='textscan.0wftuej14f4jy416a0ad50fgrmp7'>
+            <column caption='Problematic Missing Path' datatype='string' name='[Calculation_714946504234672136]' role='dimension' type='nominal'>
+              <calculation class='tableau' formula='IF ([max prob missing from file1] &gt; 0.05) THEN&#13;&#10;  &apos;TRUE&apos;&#13;&#10;ELSEIF ([max prob missing from file2] &gt; 0.05) THEN&#13;&#10;  &apos;TRUE&apos;&#13;&#10;ELSE&#13;&#10;  &apos;FALSE&apos;&#13;&#10;END' />
+            </column>
+            <column-instance column='[max prob missing from file1]' derivation='Attribute' name='[attr:max prob missing from file1:qk]' pivot='key' type='quantitative' />
+            <column caption='Max Prob Missing From File1' datatype='real' name='[max prob missing from file1]' role='measure' type='quantitative' />
+            <column caption='Max Prob Missing From File2' datatype='real' name='[max prob missing from file2]' role='measure' type='quantitative' />
+            <column-instance column='[Calculation_714946504234672136]' derivation='None' name='[none:Calculation_714946504234672136:nk]' pivot='key' type='nominal' />
+            <column-instance column='[trip_list_id_num]' derivation='None' name='[none:trip_list_id_num:ok]' pivot='key' type='ordinal' />
+            <column-instance column='[max prob missing from file2]' derivation='Sum' name='[sum:max prob missing from file2:qk]' pivot='key' type='quantitative' />
+            <column caption='Trip List Id Num' datatype='real' name='[trip_list_id_num]' role='dimension' type='ordinal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]'>
+            <groupfilter function='union' user:op='manual'>
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[attr:max prob missing from file1:qk]&quot;' />
+              <groupfilter function='member' level='[:Measure Names]' member='&quot;[textscan.0wftuej14f4jy416a0ad50fgrmp7].[sum:max prob missing from file2:qk]&quot;' />
+            </groupfilter>
+          </filter>
+          <filter class='categorical' column='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504234672136:nk]'>
+            <groupfilter function='member' level='[none:Calculation_714946504234672136:nk]' member='&quot;TRUE&quot;' user:ui-domain='database' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />
+          </filter>
+          <slices>
+            <column>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]</column>
+            <column>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504234672136:nk]</column>
+          </slices>
+          <aggregation value='false' />
+        </view>
+        <style>
+          <style-rule element='cell'>
+            <format attr='width' field='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]' value='122' />
+            <format attr='text-format' field='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[attr:max prob missing from file1:qk]' value='p0.0%' />
+            <format attr='text-format' field='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[sum:max prob missing from file2:qk]' value='p0.0%' />
+          </style-rule>
+          <style-rule element='header'>
+            <format attr='height' field='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]' value='32' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <text column='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[Multiple Values]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-cull' value='true' />
+                <format attr='mark-labels-show' value='true' />
+              </style-rule>
+              <style-rule element='pane'>
+                <format attr='minwidth' value='-1' />
+                <format attr='maxwidth' value='-1' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:trip_list_id_num:ok]</rows>
+        <cols>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]</cols>
+      </table>
+    </worksheet>
+  </worksheets>
+  <windows source-height='28'>
+    <window class='worksheet' name='Label Times'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+            <card pane-specification-id='1' param='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[Number of Records (bin)]' type='color' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[Number of Records (bin)]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221208578:ok]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221208578:qk]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221356035:ok]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504221356035:qk]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:traced_1:ok]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:traced_2:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+    </window>
+    <window class='worksheet' name='Label Iterations'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+            <card pane-specification-id='1' param='[textscan.0wftuej14f4jy416a0ad50fgrmp7].[Number of Records (bin)]' type='color' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[Number of Records (bin)]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504231649286:qk]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Label Iter 1 binned (copy):qk]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+    </window>
+    <window class='worksheet' name='Max Stop Process Count'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+            <card type='measures' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+        </edge>
+      </cards>
+    </window>
+    <window class='worksheet' maximized='true' name='Missing Paths'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+            <card type='measures' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[:Measure Names]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:Calculation_714946504234672136:nk]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:trip_list_id_num (ft_compare_pathset.csv):ok]</field>
+            <field>[textscan.0wftuej14f4jy416a0ad50fgrmp7].[none:trip_list_id_num:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+    </window>
+  </windows>
+  <thumbnails>
+    <thumbnail height='192' name='Label Times' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7EAAAOxAGVKw4b
+      AAAgAElEQVR4nO196Y8jyZXfLzJ5Fsli3X1UT8+pOaTRaLQjrSBppZUXlrxee33BWP83/mDA
+      8EfDwBr2wv5geA0bsL02sJbXe4xmV/eOds7unum7q7u67mLxzCsi4/CHZLKSZJJMkllVrOr8
+      AQ1UV2VkRJL5It7xe+8RpZRCggTPKLSzXkCCBGeJsQXAsqyTWEeCBKcGKWXn57EFINGYEsSF
+      rc1N8PbPTvMIRy3H+49k2N49xMHOJn7+i19i77DaN1a6Fj74+DMI4WJ75wDUbMHhsu86ANje
+      2e78rJTCf/tff4JavQkASMX6RAkSjIHtzU2sXb+OX/3kT7C7b8JSBJquI5PN4LmrL+Frv/YG
+      nuwc4OndG3j/5/uwmhz5xQVQlcbv/e7fRrmYhRAu3v/5T5HRJKzUHBbnsrDtOiQjOLIYrq+v
+      QZEU1q+uwzAt/Jf/+UM83HiK6+tX8J1vvpMIQIKzw9JiCXfu3IeWKeHq+jzqNsfyyhKy2TTy
+      uXnvmqUlgOVRunwJom7B1jNI53IQtIW9gyO8+OJzWFtbRj6Xh8iWsDSngZPrsKtHuKznUMxq
+      oFIHABBCsLRQxnPfvozvfPMd73fjeoFM00ShUIj5o0iQ4ORBGUMmnYaQEindE4qJToDD/R3M
+      lVdQyGUij6kf7YNreVCjgcXlRdRbDq5eWok0VgoXDhOoVQ6xuLyIWtPGXEpCy82jXMyPvoGS
+      MCwHZuMI+dICGk0DC4UsqEpjZbE0cji1DVRbFBm4SM/No1mrYmlpHk2L4/Lq0sjxZrMGW+jg
+      Vh2F+UXUmwbKhQxcZLC8MHp+5piomwy6cJCeK6NZq2JxcR4tO9r8wqU4qDYxlwYYMnCtBhaW
+      llFrmFi/sjZyPAAYhgFqtZCZK6NRq2JxsQTDkbi0shh5PGc2XGTgmg0sLC+h1rAizS8Fx9bT
+      LSwslkGFBkUNFMuLMCwbayvLI8ebjSpaDJ1x9aaJ8lwKXMtNIACS4eHDJ5D6Lr71jXciD7v5
+      yce4dG0dTx88QV3lUMhncOnSd6FHGLu3+Tk2dwxU600wV0emnMFKPgcqFL7z7W+OHN+oPsUH
+      N7bBjCOsLS7hSHLoKoW0Dnz3N749crztMGw8vAcNDLW9CrJzeTRUEeU8wdpvfmekJ4Fygft3
+      bqJ21MClhSUcgSOtUtC1aPNbpoWPPrqBhWIK1d1DZItzaMoiFiLO79gObn78IdIZDc89fw0b
+      tx/D4ArpQhGXr6yN/A5a1T386Jc3cHk5i6OtQ+TmC2ipIhbywOp3R8/PrDr+9M9/hrXFDK5e
+      X8fG54/RkhqyhblI89uNPXz6+SMsLxXBnDpSyKG6twnttd/C76yM9uTc/uwG8suXsXH3Pi4v
+      LKJCJOZICoCaIA5AdEhmIV8YvXMFsf7cczio1OA4Fi4tz8OV0SdfXruETLYI7lhYXSmBc4Ao
+      hnQumipWXl7BXDqD9WuX0LJM2BZFIasBerQTrHm4BVOkAO6iuLQKy3KwspCHUBpIhPF7G3dB
+      cou4tr6Glm3CMhnyGQKSykaan7sUeioNcIbS0trx/Ig2vxAMmWwGq5fWsX9Yg0strK4uwuUy
+      0ndgmjYkdyFchtKK9/zL8zkI6JHmNw0TGpFYuXzVm59ZWFtZiDx/KlvEQs6FzQSUnodwLSxf
+      vgyNm5Hmv3z1Gg73D7B+ZQUGdeBYLnIpQEvnEhsgwbONU48EO46TjD/j8dPEcs56/a7rgnM+
+      +sKI849lA5imOfUDUEohhEjGJ+Mngv/yp1KTefB75x96F6N2iI9ufo50JgulZ/Gtr38VAKZS
+      gTKZDNLpdDL+jMZns1noug5ComjP8c8/7XghBAgh0LTJlJfe+YfeJV8oYnllFUS4YJQiIUEk
+      uGgYegLYlgHGFV56+WVQNbnUJkgwqxgqAMWFVXx1YfW01pIgwakjyQdI8EwjEYAEzzQSAUjw
+      TCMRgATPNBIBSPBMIxGABM80hrpBdzYfYbfuoKS7mFu+hmuXR3OvEyQ4TxgqAJcuX8Fh4w4e
+      PdrBVb2IxVJuajKSlDIZf4bjJ+HhuK7boQ+c9fr9ig6TUiF65x8qAI8fPUAqu4CXX9aRLZcx
+      NzcHy7Kg61HSWMKhlErGn7Pxu7u7uHbt2pnNHwQhpPMvjvmHCsDLr3954CKmQTL+7Mb7Y8e5
+      h2maXdef9fNPe4/g2MQITjASjuN0FZO6SEgEIMFIcM7huu5ZL+NEkAhAgpEQQkydCDWrSATg
+      goLxybOueiGlTAQgwfmBlAqfPqnFeD8J27Zju98sIRGACwjKBQw6ua89CD+BPjkBEpwbNG0X
+      bECl5HGhlIJSKjkBEpwfVE0G043HBvAFgFIay/1mDUMDYYc7m9ipO/jC1QVUWQbX1hZOa10J
+      poDNRKwnAHBxYwFDBWBp7RK2D27jVx/cRm7hDayW8xBCTFXXRSmVjD/h8abD4DAeep2Ucqwo
+      KuccUsqOGpROp8/0+f31T1rcq3f+oQKw+fAuZCqPN9/6NdSNFDRNm4qH4SMZf7LjGw4HF2rg
+      dZPMr2laRwDOG5Vj2PxDBeDF197Ci+2fV9pVrBljEzPx/MmT8Sc73mICpitCrxt3E1NKdXZc
+      SumZP7+/nknv0Ts2MYIvICwqYLsiln5uvhEM4EJ6ghIBuGBQSqHhuBBSQcYgAL7hSwi5kLGA
+      RAAuGJQCbFfAFRJCxiMAFzkYlgjABYOQCjYTEEKNJQCD1KXg7ymlF65NbiIAFwxcStiugCMk
+      XBH9ZT1oOtg4NPp+H/T9u647lQtzFpEIwAWDzQSEBKQCXBE9cHXYdEJthqAAXMSIcCIAFwwm
+      5SAEIADYGHSIisHAQwQmqPJomgbLsuJY5swgEYALhrrlQtc8Hz8dQwCqJoMbQp8IRo4voido
+      aCCsdriL/YaDrKLIL17G5ZWECzTraFG3HezBWJToqslCbYZe/s9FiwUMFYC50gKsp7dx9cXn
+      8Hi3gtXFUldgZFIk409uvOm4XrQUQIvyvmv9//f+vmYx2Kz/et/o9X8fhycojvHT3CM4dqgA
+      bG/chUuy+PSTT/HCF38NjLGpyXBSymT8CY6vW+7xy+r2E+LCxnMh0bBdmCEEOtd1u14Yy7LA
+      OZ+YizPt8w8S4EnnHyoAL73xNl4CAHyp6waTdugDvIUn409uvM1lh+viivBuir1N8poOhZAK
+      QvVf38udcV0XjuOgVBqvUXrU9Y/CtE3yeudPjOALBtM51vuj5gQ0bRdcqVC3aa8NQAhBtVqd
+      bpEzhEQALhCUUjADhm8rohFcMTyWZ5gRHKZqNBqNyRc5Y0gE4AJBKgWDHeu3NOIJUDEoNELA
+      B7hBe9FsNi9MdlgiABcIjMuuYFbU2kA1kwEIF5iwF10IgWazOeEqZwuJAFwgOK4ADxDgqBtt
+      l662BSAskX6Qt+Wi2AGJAFwgWExABF5YO2Ik2D8BeAh7NOwEIISgXq9fCGZoIgAXCIbTXcDW
+      ZKOzwhgXaLaNZTdEYAbp+q1W60LYAYkAXCA0bBdawL8v5OicgIblwqPOIdQLNDToVq9PttAZ
+      wlABkFKAcwHOXcgYsosSnCwMpztCK5UKZXgGcdB04A8Ju3bQLn9R4gFDQ3IHO1u49WADKWoj
+      s3IN33onvGNMgtmAxbp3a9UObuWGjGnYx2oTDfEaDVOharVap0rDecVQAeDMwuLKGtjRAXRd
+      g2maYIwhk8lMPKGUcqpmC8n4weObFu3asYUCDJshlwqcCoEcXwDYa1gdcpnJVd+9/cJYPpRS
+      nf/btg1K6Vg9v6Z9fn/t03CRgvOPqAy3jjkOZF+4hnS2gEzae1C/Y+AkCHYcTMbHO77FZBdH
+      RkgFDtJ1Pee8iwtkOMf1g7gU0HQdeuAevbwbKY/n8AVhnOeZ9vmn5QL1zj+cDl2cx9xE0yQ4
+      C1gh1Ac2JBaglEKl7QL1wYWCHni3Rnl6pml5OgtIvEAXCL0JMARecGwQhFRo2t3qSG9WWCIA
+      Cc4FuJCwel92MpwOQblAK2A4ExCwHk/QMCOYEHLuk+QTAbggoK5Ar6eawCuUOwh1kyFoSmpa
+      fx7xsBOAEHLuu0cmAnBBYIbo/4SQoTkB23UHqYDCrxHSp0aNyt5KVKAEM4EWFQhTVoZVhjho
+      9ld4CDJCgy7PQUgEIMFMwB2wUw87AfZDBCCYFRaF7MYYG3nNLCMRgAuCQe7O3uiwDykV9lv9
+      BmxQAKKQ3ZITIMFMwHEFwmKjg5rlmZTDCDGQXT7eCXDejeChgbBWdRcffr4J0dzByktv4yuv
+      vzjs8gRniEE7/SA36JFB4UrZFfUFvECYj17aRBgutACUlpaRUg9AMiVQx0q4QDM8vuWw0IJR
+      NuVd1/sv9ZOKAYJ+NaflsM71fk2gQVwg/5qw9TQaDZTL5cjrj4pT5QIBKXzl7a+CWk3ky6so
+      5DwOxaxyYZ7l8UIhlB8jJEK5QBUzvNcbV8fcIdd1oWnaQC6QD0JIV60dpRQMw8DKykrk9UfF
+      qXKBAA2lUhGlUnGiyRKcHgbl/zYHlEbZa4QXuR3XCPbbjgYFwC+edR6QGMEXBGFcfqDNCO2h
+      N0ilcBjiAQK6BcDfbYdBqX4K9Xlqqp0IwAWAVxArXAAU+mMBdZPBHhAfCHqBotTwVEr1uUId
+      xzk3nWQSAbggcAa80AT90eD9JsUg5864KhDQHwtgjJ2b+EAiABcEg9ydhBBYrPtl3GvYGKTZ
+      2O54cYAwQhyltK+q9KwiEYALAIXBRjAhHk8oiP2mM1C3d/ix7z/KCRBGiWaMRYohzAISAbgI
+      UMM5P27P6bBdH9zlRSrVIdVFVYF69X1KKYSIp1P9SSMRgAsAIRWsYYkvblCvVzgY4AECAB44
+      AaK+wEEVyO8kmZwACU4No4rgBv9+ZLC+xJkguFSdv0c9AXojzZzzqTsJnRZ6AmEKB7vbEHoe
+      V9aW0aru4eaDHeSUg5Xrr+L6lf7IXoKzx6giuMG0x52G0+kiGQYhFZRUgD6ZF8gXACCaG/Ws
+      0SMADD//6S9x6cVXcWVtGaWlJUh6D/u1OmiqhOX5fMIFmsHxhk1DeT0+Pn5SxWHD0/t3G87Q
+      JnNUANR1QSA7npzgtWFJMr7XB+iOAVBK+2gPM80F2t96ilR+LiDRKbzxxTfBrCZyC2soFLwi
+      KbPIhXmWx1vcQkrXBr4UdUegvmcAOO77O+haV0hA0ztz9F4bxgUSQnSuNwyj83elVN9aZ5oL
+      dOna81i8t4nlVV/V0bC8vAQsL0284AQnD9sdTVkYBz51Itgke+j1nHdKJNq23RlzHipG9IkR
+      c6yxOownOHtEbYQRCeo4JyCqF8cnxAHeDuufGufBBugRAAnLcVE52D+b1SSYCIOIcJOAkOP7
+      jePG9PXq4K5/HugQPUawhivXrkHPJvTn84Q4TwBC0GmWF9ULRAgBYwz5fP7cCYDW+1+zUQHS
+      k3t5Epw+DBbfi+Zxh7wTYBxKs38CBKtEhHl7LMuacoXxokcAOB7d38Rh5fBsVpNgIkRtiB0F
+      GiGdRPpxBcCPAvsIOwGOjo6mX2SM6FKBqvsVvPLWFzG/nAS8zhPidlr4RvA4AhAW/Q0TANM0
+      p19gjOg6Aba29kE4x9qVy2e1ngQTIG4B8ItsjWMEM+Yl03c16OjxAimlYNv2TGWLdQnA9efX
+      sXp1HdwezBZMMHuw43SDAnC59+JHdWMSQsA5B2OsS2jCbADG2Ey5R7sEoFrZxuPHO7AdT4+z
+      WzX86qMbqGzfx93HB2eywATDIdVwJugk4EJGqgvaNaYtAEEIIfpOBM75THmHumyAl17/Cmr1
+      v4ZoLzozNw9qVvHxp4fILn4J11YLCRdoxsYLqcBcEflljUJ1Nqnb0el77ztIMBzH6ej3/t+V
+      UmCMdXqI+amStm13VZEYBydcF4ggl8shnfZ+res63vnaryOfzYC5CtlsUhdo1sZLV0BIFZkb
+      M4oLBACOAFKpVCjnJowLBHi7u19HqBf+em3bhqZpXdyhcRE3F6jnLi4M00U6ddz1by4/B6Kl
+      Oi9/gtkClwo85h7OXE6mAvXWAgpSowHvlPDthVlBjwCkwKiJVmu2XFUJBoNxCRbS4X3aewLj
+      eYGEEKHFsIIGL6V01gVA4mh3Dw0r8QKdF7givDHGNBiXCuGN6T8B/N/78I3kWSqo2yUASinM
+      r6wC7vluevAsgboytCz6NHDbXqBxc3p76c+9u70vIDN7AtQOKsjOZZDJJd2BzwtsxmPNBQCO
+      i2yNcwIQQkI7xodxg2ZWAJYurWBv8ykcmpwA5wUGFRiS4jsRbFd65VHGOAE0TesTgOAJEOQJ
+      zawAABIKaczls2ezmgRjw4o5Gww4TnCJo6yJ/7IH/e8zLAA6XnjxuZkyUhIMR2/RqzgQVlF6
+      UvgvO+e8o1L5KZSzgL5AWDafh8wkPv/zgljTIduQSnU8QdMi2G3GFwD/dIn75JoEXQJwuLON
+      7e2nmFt7CQBgNir41c37uFLOwVR5vPPW62eyyASD4ZxA/rZS8Z0sfhwgaAzPUtnELgEwG1Wo
+      bAlXVhcBAIXyCtK4jXw+j8Wl9WemR5hP2spm+22hWVt/03bH8tZE4QIpBZgODY0Gjxsh9mnS
+      pml25uSc91Gnx13/iXCBXnjjq3jhje4Bb775JVQPDiAFR6HgCcYscWFOYjxjDLZto1jsz42e
+      tfVzFZ0HBETjAgnpRZd7+4P548edL51Od3qT+TVDCSETfQ6n3CMMWFhYwsLCs1UXKFjpbNZx
+      EjYAALCYnj8sVxjAwBP2tJEUxw0BpXSmXHXDEGdJlK77xhRgk1JCCNEVJZ6lmkGTkbIvOPzy
+      3ucBNjuZdTosvhNQCNF1AoR1lTkrJAIQgt7jelYhpIR9AicAAQFlHKmY3JSc89AuMrOARAUK
+      wXlRgYRUkDHnAgBecaymHc8OTQiB4zhdO/4sUaITAQjBeREAV3icnbhBCMF+Mz5KfFgxrFn5
+      fBMB6IGfxzorX9AwMFcObHc6LWpmfJWdTdPsM6hn5fNNBKAHfhrfrHxBw2C7AjEng3UwLht0
+      GMKKYc2KEZwIQA/8En+z4qYbBsZl7NlgPrgQcGOSrjABmJUNZqgXqFXbw2cP90DsGvJrz+Ot
+      1146rXWdGXxvxazsUMNwUjEAACBKwWICmdR0hZL9phm5XK7r97OywQwVgOLCErjzALl0AVar
+      eSG4QA3DQXlI9fdg6T5KaSgV4CzXf2engSc1L7XwoEkBNZ4nKGoLVKUUTMoxn0v1/X6SGEmw
+      VpCUssMRGhcnXBeoG4Sk8Nprr4OadcwtXb0QPcIeHVbx64uloffXNG0gX+Ws1//ZroFPtpud
+      /+v6eFpsFC4QAOgEcNx+3s+4XCAAXbu/P14I0ak9NA5OmQukYXV1BVi9GNWilVLYajj49SHX
+      MMZACIFSCpzzqU67k0CLnpburGAzfmK8fSklpJShecSniWfKCJZKoWq5Q49/P0JJCJnJJm82
+      Ox3dmUDBdk/OyJ5UlYobz5QACKnQtIbrncHaNrPiqQjCjrEbzFAo5dUdjbH5RvftZ8PT9kwJ
+      AOUSTccduqv1Zi7NEpRSMOjpnQAaAcwTUrl8luhZ45kSAIvydtGnwdcEBWDWTgBXSK+R9SmA
+      tHV/q0flojGeCMHPt5cyfVp4pgSgYbmwXDnQBuiNAM8KY9EHdSVOgPs2AN5EQZVLSIX7+0Zs
+      EeLgZ91oNFCv12O57zh4pgSgbnvqz6Bd1PcAAbOVtOHj1PR/eCoQ4BXJ8ssk7jVsMB6PEPYy
+      Quv1+plsOM+UADjtF2iQYWfbdpfLb9ZUoBblODW/SXuXZ1xCSM8g3q07kGMG3obBf+GVUqjV
+      aokKdNIwmVdGcFBTubAWP7MEdkL5v2HwTwApFSiX2KrZbYIcYulHEDxhGWMdlsFpI4IASHz0
+      /s9w/8nOya/mhFGzXGgagTHAs9G7A80aH8hiPPZK0KFQqiMAhAB1i+Gw5dX2V1DgMfnv/RO2
+      0WhAKRVaXv2kMTolUgo0GgbUXGsoF4i6Apm0PvILOksujWEzEAB1k8J1u8lZ1JUw2rVrfCMv
+      jK9yluuvGhTAdAGkQVwgohTywoBv/EIKqPbPm1ULekA1ZFxAyuERXC4kUiE0jWAAzK++cXR0
+      1CmeO+qzOVUukDeTjueuP4fi6mUUCgUA4VygTzbreOv6EjLp4R/MWXJpHO7xYITq5/g8PKij
+      aTpdHBOlFHRd7/rdWa6fSjUVDwYYzAVKcxslWvG2fADeTub9HMwNJgBcgaFrUErhyGS4stBf
+      Zj/IJfL5QK1WC5qmwXXdkfygE+4RFgKi4ZXXv4TLy+Whl203HNgnUKYvLkil0HS8IzeMRly3
+      XVQa3al7s2YDOCdIg0hLevzyDwEBRhbOFTJawM73/fspk72d5k8DsRnBLduFdWpErfHBA0Gk
+      MC+Qzfr73M5SFWMAJ/r56jK6AToqGBc1YMc5R7Va7XI9n7YnKDYBaDgcR8bskcd8UFd2MpzC
+      jGDqCpAeJ+OshOsBT61oneAJkBpLAIZvCo4rwcXolErOOWq1WpcA2Pbp9qeLTQBMylGPqZTG
+      ScBkHG7b+HJCToCWTeGG+P1nKRZwYoEwJaHL6N/dKC8QExJcqpFMUsYYms1m3+9OE7EUxlJK
+      oWG7MJ3ZeVl6QZmAUp6aGxYHoJRC9exss1S/Bjg5KrSuOIiSkWwAAHBH8IEYlxBCQkoFTR98
+      T79pRjAn4LRVoFgEgHEJyiWOrNnizgRhUA6NEAAqNKDEKEVviQVCyMzwgRTQR0yLC+Ps/gDg
+      SjU0UcYVEqIdMEsNcQr2esPOrQ3QtDwOjTHDJ0DVYp0NrtcL5AVhKFzZLwCzEgxzuQQ9ISZo
+      Woz30kmphvKBGPdat06SS3DaG04sAnBoMOgaia2c3knAdI6rHbdYd4cSpQCbMXDRzxSdFRXo
+      JIlwumSR1R/AO40G2QFKKbhCeqrmBAJAKT1Vz1ssAmA43ovfojy25mpxI6g/c9HNaORSQnIe
+      6t2YFS+QRUVXNDZOjOMBAvxgWPhLqtp/I4SMtBXCcNqu5wgCoLC39RjVZn99Rx++94cLNZBo
+      dtaoO8enExfdjEbGJZQIF95ZUYGqFoMWd0NgAFBqbBsAGGwIS6Ug2qcDm2AznLR10qQYLQCS
+      4dNPbuGgcjTwkobteh4TeRxtnTUETwAhZedLAjzjknPuUX1DVKBxT7WTyHelMfUDJqr7Wcbd
+      /X0MCnRJqeD/aRIB8PuzBWHbNur1Our1OgzDGPuewxCBC5TC8lIZlLKBZLimRdtlLhQapoOV
+      wuDbnhWZrGmxTn8qxxWwqQudeC+75TBAcijlvWi5gHPCoRR/dmMbP3jzcuT5TdNEs9nElStX
+      Ylt/yz5e/zQ75DytwMwsQWjed6QLx/PXR1Q7FNA2cEXoOryularzWY7bZE8pBcuyulyjN2/e
+      7JRX1DQN3/jGNyYupzIRGe5r3/pO16+C7iulFOqO8MhJRMFkcijZ6yzIZFJ6UVRN0zxBVYAk
+      Wuc+rjChQ0LTCLjsJnpZjovbNQO/83aq4xUaNX+j0QClNPS6SZ/f5qqz/mnIcDoESm4Nzdwa
+      QAjSym3z3iKeLm33p5DhhDhXKGhtsh1v2wLBk2vU+n3Xs/8ZMcbgOE7nhfeFZ9J3aHwy3AhI
+      qTrqhUYIqjMYC2BcQPT47VjAFWraLjTirb/XRVpp2dhvUVRa0VyFSinU6/XQmvjTwIjDC6QU
+      dMmR5aan9ysFXYznAfIxMK20zbgF2g08xrRne13Pfq7A8SOoWF2lUwuAKxWswJczi7EAxxV9
+      Yfkgs7LlMGjtK3iPd4MyFyDA/f1WpLmklGi1Wl01RuMAjSEIRqCgKQ4FhSLzbLqUmkwd7Y2Z
+      +Ajq/VJNljwTTIwJcoWA+PlCUwuAwzgoP/4wZpEP1LC7awF5O/3xF9NVCqVnZxNCQCfAw8No
+      1RBM0wTnfOLir4MQRxRYU55+DgAZbiErLGhysg3L5eHVNYLBL4X+DSUKgrnC1Wq1628zJwAt
+      m4MQz7ugCwbDMLq6gs8CTCoQlABCgEbALRoMv/f6tz2WqMJGxTPC/K7npmnCsuy+56xUKp3i
+      unF9UV5BrOlPVi3o7iQEJedg4nsNygvujf5OEw2mlIZ+hnEKwNRcoEOTQtcI5p19ZLgB4RC8
+      /34Fb7/9NpaWZqPBtkV5l5pLCOniA5lOUAB6v0ABoik0HI7dmomN2592vqDHFRP/9Le/h1LJ
+      q7fu6/+AZyA2m00sLCxMvX6pwhms4yIlXSCQtDoOAa4XYa5hPwrcuT8mEwA/Glyr1UIN5jhz
+      h2M4AVykJUWGmwDR4EpA03TUarU41hcLaiFqmRMwdh3nOBuq/wTgIJBI6xre+/AOGGPQdR0t
+      KnBouLhz/0HnWv908BGXISykBIshwKj36vtTxBWkQp+BK3sqRhBCJooF+CzRQYWyZksAHBdF
+      dqynKeXtorVabWbUIDuk67kbOAEoDdgA8li3lUqBCQWiJIgSMKv7ndLpWzUbGgG29g47X5Rh
+      GF0BsLDWQJNASBVLu6JJ9f1B6D0tRTsWNOyaKPAbaDQajdDgH2MstkDj1AJgtppIc7uzm2ht
+      EpRpmjNTXjzMM2UGdtSugrhSdWJCLpdQUkFTEgVWh+m4EFKhajKY1BMqmwlsbGx0DLauGIJl
+      xeIJclwRCxO07wSYAhrpV29c0Z8EM4kKJKVEs9kcqOv7FSTiQCQBkJzCsPonVEpBNA/6jlL/
+      oRuNRgxLnA5KqVDPlO9VkVLBcLoFwKdDOK4ACEFKUuTcBkTbGN2p2+3cAq9TY6PRQK1W6/NY
+      SCljMdjC3Lhjox0DiAth6k3Ybj9pefXd3d2h0d641KDRAqAUbt94H/ce7fX9qVKp4LDar6cx
+      4QVDzqLYKeC99E2LoWExNG031IPiB8JcIUECL0aw8plveBZoFUR5Ec7HFbOLV2Qxj6Nz7969
+      js6vApyiOOwAm3oV7aaBpkSn2FVc6DWEaTsPIIhJVCBCCCqVytBr4hKACF4gAf7KqOIAAA5a
+      SURBVCEBx7b7uEDbO7te7mfP5+rzRKrV6pkUlrr5tI7/8eF25+sW6viQ8rkoFuVwXRcti3UV
+      gVJQYFwgo5NOLdHO4ykFyj1B8O0E6gqPXt2uKyqlBHUFHh6aePVSEY1Go8sTNMnzVwynM3ZS
+      LpAuXSgloUBAMLpJ3iAEeUOMy661+Ezg4L25BDgXHSZr1PXruh56nX9vwzAmeo8m4AKl8NbX
+      vtv1K59LYVhWO8+2pwu48HgrfjBobu64QNJJc4G4kHj3bgUqoIsHD1KfiyKV9xwOZyA4Dt8T
+      oMNzYaI/7U9D9/OqtqFcyB5/lA2HwmICd/cNLK9YXeud5PmZUNDbzzMpFyglRPvV9zAxszSQ
+      Csml6i4aFvJ5KShwBeSmXP/x9J4ATPoexcYFEkKgZVihh2pQNzxtd+jfbByhYozmijTbahHt
+      4ZVobd1WKRU5oynYRUUphYbldgzkv7m/i+aU/CgnLhdozAk1vSpQmLpDcDL9jG27Pwg5CSYW
+      AMuyughlQbjiOGm6Xq+fmjuUugLv3TmIlDjCpZe4wWj/y+kne0Qx4Hq7qCh1XHeIEIKWYeHf
+      /eX9yGS6MMTRpmiSpJdR6HXNDtL3XR7/93+qXqAwmKYZavQA3s7gP/JpeoJ+9aiCRkQynpAK
+      XChYIR+kKyRkT1RzGIJGse2KPv5LyzTxBz9+gIPmZIZb04njBIifpBjMoVZqcEO9SYJhoxBX
+      LGBiATAMI1TnA7ydwQ+IBGs/9iLOk8GkHO/dOey4J0dBKQWXS5gO6xNi3q6JH3V5wZqo9ZDU
+      xZRkaFGBP/irB9iqeicn4yJyplkcKoR2AicAbwfoeLsQVi/lHGiXOmk7CoSUfRl302CQJ2ic
+      92oiLpBSCqZpojGA+akRoGoyrM3noOs6tre38eqrr/Zd99/ffwKTCXz9xSW8dmUemWFFZEbg
+      J3cPYI2RNqiUR4dwB5wANovuemRcdsqBh30mWW7ASZVgMIF/++NHnTVmdQ3//B98aehzm5Rj
+      qzalK9WPAcRsAwip8PHmsY036O4HLYqDgAr49vUFZKf4rgHPSWGaJorFYtfvpZTY2NhAqVTC
+      2tra6PtMuoCnB/WBxVoJIdiu250dYW9vry8gJKTEoyML9w5N/OFfb+Jf/d/b+OOPtrBTs8Zu
+      wWM4Ln72oDKWZ0Mob+d2KO375rjwToCo9/PbiXIhYfVWRSYEGW4jLRyvrDch0DUNetvL9Phw
+      OF3i5/cOYE/ZGeYk1B8Anefx/w36vLquAbBdm96ADSuiJaXE/fv3sbW1Fdn5MpEAcCGwsV8b
+      +oK4XHYZfo8fP+566KMW7WSPaRqBzSV+sVHFv373Hn7/R/fw07sHsOjoEhlKKbx3e3/stj0+
+      U9Gm3QxJwDsBxq1uYTEBk3KIsPUSggKr9uXdEgLcG5Jo07QZfnJ/PMEOw0kYwNOg0qKxtFsN
+      CoBSCnfv3sXe3h4IIX2ZZIMwkQB8/nh/pIeEEIKdwClwcHDQRQ67u9cK1dd1TcNOk+KHN3fx
+      L/7PZ/jPv3iMz7frXVUcgqgaFO9vVMd+SRQ8r5Hl9KtAUmGsXge+J6hhuwNtkLRwkBFW37hH
+      lfDcCaUU/uKz/YGZV+MgTg5QHCCE4Gk1vpRRIQRu3bqFg4ODzntg23akaHEkATCa9a4Oiz++
+      tQmQ0UNdIbHbOFZ9Hj9+3Pn57n5r6EtLCAEIwee7TfynXzzBv/zh5/jhJ9vYbzgdQ0ophR9N
+      sPt79/cEgLFwjlOfKjMCtiuGl4QhBAXaX1pmp26HFr2tmgwfPB5fsMMQNws0DtTahMJp4Bcv
+      vnnzZlefAR+93KwwRGqSVz86xI1bdwAAd3abaEaszUIIwW7dAW9zg46OjtBsNuG2uw5GvYem
+      EViuxE8fVPBv3nuAf//effzy/iE2Dg18uFmf6CUhAJoOh0P7d0elxi/rZ1E+8gtNSRd5twUo
+      2f7nJY1vHHZ/nkopvPvZHlRMRqsu4w+CxYGnVc/e8/+Naxe0Wi3cunUrlDYdlYs22gukFDYe
+      PsDV178O0zThMIaUZGMt9mnVwvPLHh3izp07WHruCzCpO/Hu9rhqYePIgpAKKZ2MtZYgF6Vl
+      M9iU9ZPECJDSwu87qIaOahfMGbWWEjtE0T3emaq5ddzYquHVS4XO7/bqNj7arIVG2cvOPqx0
+      Ga6eC/lrP4hSSAnn2F/vLTMWLtC04xuWiw+feJ8FAUE2reHyfBZLxexAj1KwSV4wYyzsefzm
+      271lWcbjAkHDN7/3fRCiQdc1pFMp6Gq8KmUVg+HqYh7ZlA7XdfHhx58ig0UIrb/b5CgEuSST
+      1EYKjrcZB1ECROu+UaA/XD8GlAUfo6xOpwIFlEKR1/C0VoCeSnVIdu/e9ZrV9doTGW4iK0xk
+      pY1G7jLcVH8Tul7MsRp0JYJswPZ6p+cCTTs+eBsFL6C4UbGw26C4spDDciHbF1MJCsAoTpFf
+      nCDoKp2gSR5BKpWC3m55qSneri4QHUop7NSPVZ6W5WDB2UFqzLLccaNhOhj8pp8CCEHONdBo
+      mWhYx3nGt3dD7COlUKBVoE1pKzt7XhrqsNsrgTyrz6T6Ewa/iBblEhuHJj55WsdO3Z6qL/Eo
+      d+jYXqBJakkSQlBpUY8mIBVMyqEpiQV7Bylx+s2RfRw1rbN/NwjBHD3CxqHnDfrzW7uhXKYs
+      N7s+ewJg3tlH1jUGqiRzrA5NxU9DOA141ecUtqoWbjxtYLtmDfQEDrvHKEN4bAHQgsfpGFDK
+      swVagXIkBAoL9g7S4nQbo/motqyZ2B1zwsLDrQM83G/hQSVkV1fSiyP0GnrwhCDvNvuGaJIj
+      7zZm4vmmgS8I2zUbHz+p40nFHMtB0Ww2h+YfjE2FUBOqDIQQ1E3Wx38hAMr2Llq5S6D6aJ3W
+      W8SUvvH2eE1xnKkK5IMQ7GxtYteC1wOg5/nybmuwJ4cQFGkFgIKdPu7lPMdqIEqdewHwQYjn
+      qvBpFSulLNYX8siOaMzu5xeXy8efTdBgJmpMd8Df3LiDn3x8Z7zVByaW6ji5o+ePkGS0Vas6
+      OU2ToWu8kmOnGg7rjTXNeKUUJNFCn43gmHU7cP6ez2/QSa2mNIJP6vnHGe+jmEvhi1eHN3BX
+      ykvaCRbXDRrPsTTJiwpCyGCdixBoGH20xfoFzNDmSAiBDgVMmrfb+/ldkJ1/ELzyNFGvU52e
+      A70CEFuf4AQJziMiCIDAT3/0Z/jg5t2TX02CBKeMSFSI3FwZgp2duzJBgpNCBBsgjedfuIb8
+      wujkggQJzhvG8gKZpomDShUNY3Iqq8s50qnJbe9k/LM93vfpa5oGXSNd5Wgizd9DhRjbDWqa
+      JgqFwugLk/EzOd6yLOTz+Yk9aWe9fp/cNmltqd75T10AEiSYJYwvAEYdv/rFL5FbvoZvvvPl
+      yOP+4od/hKsvv457H3+M3Oo1mJThn/z9H0Tyw+5s3MDTA4onDx+gvHQJDe5ivaiDZ8r4zW99
+      feT4RmUTH322jaPtR/jCK1/A3b0DrJYK4CSN73/vN0aOP9jZxIefPcCcZsOhBGargfzKOgTn
+      +Ht/57dGhhO2Hj/A3cdPUd3Zwasvv4K7BxWsFufASQbf/963R85f2XmCn396HwsZB46jwTCb
+      mFu+Cik4fucHo+dvVQ/wFz9+H8WcxLWXXsXdDz9GfnkVNVvgn/2j3x75HTCrgf/3l+9jIctg
+      OwSmZWBu+QqUEPi7P/hbI+eX3MEf//BdFLIc6y+9hjsffIS5lUuoOxy/9w9Hz29Vt/C///wD
+      vPz8KuqGCY06gBIwlt7AP/726yPn/+u/+lOkl5/Dg08/xmuvvIK7lRquFLNwtdxkcYC5Yhl6
+      hKBVEK9+8cs43NvC/HwJiugoFfKRxy6vrUKTEqX5MhQ0lIp5ZPNFjIiCd1BeWUYaGt78ypvY
+      erqNcrkIPZ1DPhNNf9QJsLp2BflCESnAewYtjcJcNtJ4IgUuXV7Hm299CVtPd1CeLyKVySOf
+      jfYAqVwBpXwa+UIJOhTK8yVAS6OQjzh/KoMrqyWsv/gGjg62USqVoBRBqTgXKey2u70N23GQ
+      LbbnL7fnj/j8ld1t2Izh+ive/PPz8+3vMRr1Rc8U8crVAo5sDXO5NArFeUBKZAulSOOvv/w6
+      mkf7ePPLb2B7e9/7/LNzyKb1yVQgzhxkC2XkIr5AANBq1KBl5mAbTcyXS2iZFMuLw8PYPqTk
+      oEzCbNUxPz+PpkmRS0mQdAGFfJScAgnLonAsA8X5MuqNFkpzGTCloxzhSzCaNTQtF6VcCnqu
+      ALPVRHm+AMMWWFoY/SU0qhU4UkMaAsVyGfWGgVI+DVelMF8cvRG41EbTdpEGRzpXhNFqolya
+      g0EFlsqj55ec4ahhIp8mQCoHarZQKs+jadhYWYrWwsm2bbjUQjpfgtH05jepwGKE+QGvuDJ3
+      KZDKg5pNlMolNA0n0vxKChwe1VAu5mC7BOA28sV5OLbdxfEZuHazCSZ1cGqhVC6j0TBQyKUg
+      SDqxARI8e7BsG3N5b+NJqBAJzgz3bt+GC6BZP8Lh9mN89nAbjm2i0ajiwcMtHOxs4t1338PG
+      5haqRxUcHdXgOBbqTQOAxKOtHUBQ3Pj0Fo4O9nFQraPeaKFaOYTtUFSOarDMFm7dPiZvui7H
+      f/jDP8KjJ1sATpkMlyBBELWjI7wA4O6tD7C9VYVWKOL99xnW1+axvHQNr7z8Bso7Bzh4fA93
+      7RasigWaLaBYLuN3v/9dIJ8DlMDTp5t49PknoIUVXCplQLmD2k4FpLSA+fkS8pk08AZgmBZ+
+      /z/+VziUwjS9WFYiAAnODNeuXcbdO/cxv3QV80vrqBoUb315CUxIzBcX2tdcA1yKdZ1AmBRc
+      T8GrWEOwUiwAmob1K2sovPoFyFQWpawGCQL+goGazbFYzMIWnrPBdTm+8c5bSKV0fPmLXqnO
+      /w8OhOWomFigngAAAABJRU5ErkJggg==
+    </thumbnail>
+    <thumbnail height='192' name='Label Iterations' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7EAAAOxAGVKw4b
+      AAAgAElEQVR4nO2d2ZMjyX3fv1m470bf18zszF4zO+SelBVmkNRKYYpBh+Xwg8N/gCMcfvFf
+      4Tc/O/TqsEOhwwrJshm0admmRIkUd3Y41+7M7Bw9fTe6ATRu1F2VmX5Ao7sBFK5GFXowyE/E
+      xu6iC7+qRNUvK3+//OYvCeecQyCYUqTLvgCB4DIZ2gFUVfXiOgSCS2FoBxAjJoGblI8OUDcZ
+      AICZMo7y1ZO/MBxmjlAvZrHxahsGPfuOIZdx9+596JqCTL6Ceq0G5mjdxmEm1/P8fjcaIRBc
+      lHL2AOHEMvYe/xrbh3nUKiYiiSiquo1bb1/H1ZSEu/de4uFXv0EiHIIVWcEffP4Z0hEJlqHg
+      F3/zd/D5QkjECYLgqNRUSMEwLO7HQgIIRFaxurbU9fzCAQSXSjw9i62N5wgwP1ZXVxEKylhc
+      WYLJCGYTcUSiEm6+/y4oKGaiQfDIItRKHpmyivUbYSwtzCEan0FqJgafKWPdH0G9riIYS4AY
+      ZfgiMz3PT4bNAimKglgsNlKjBYLXhZHfALahIluSsba8CELcuKQzCrlD+MIJKLUq0ukEZJ1h
+      aT7tmn1ZliFxG7IJwFQQS6VRKlWwtrYCyYXG6KoMEAm5QgWpaAA8EIFWLWFh9QoCvtHtq/VK
+      x7WnkxFotoSF2dTI9m1TQ65YRywI2CQEQ6kiPTeLck3D2vLCyPY5pzg6yiOdjKKmM/iohnB8
+      BuVyGatrq/CNfA848tkjJFMzyB2XMZMIgUphGPUyZpfXEPJLozvA9tNneFmTsbq0AOKmB3CO
+      rx7ex9LSKnLHedR5HDMRYOEH33cld0ttAz//+S+wvrqIulKBn0RQOtpFYPEaYul5zMaCI56B
+      4e7f/V8kFq6ihjDCVg2yUkDQJsjbMXx8fW7kNhgWxeazx+A+H7KbGSTWF8FYEOEA8IPvfw+j
+      3g1NM5Dd30SxUsWN6+vYebGLGvMjHA1jefl34BvRPrMMPHv0EEjOgtgyosEYjvd/jtD8Onzx
+      WazOREayzxlFPrOJrx/pIDMLiHEdhlUF6hbiqg+fvbc6+rMUS4RhGgwj/9ptcADrV66gWK5A
+      1QzMJcOg8Ll2Gp8/hMXFOYQDErgvAmapmFtahqpqCPpHvbUAIGF5eRmJxRVYtTw4sxGMpKHp
+      GhKxsAv2geP9V6ChFKiuYm55CapiIBHxA1LAFft6LY983cb1a1eQK1RgGioW51OwKHelE+Kc
+      IRoLgFMGSkJgloqZxWVoqoZwwI3wlAP+CCLJBIhaAmU2fMEETEtDPNZwLhEDCKYaV2aCdV13
+      w8yl2bdtG7Zte3qOSf+NvLZPKYVpmp6ew6kNQ71nFEVxNKIoCiilDt9wB8MwPLXffPj9fu+y
+      wl63YdLtU0rBGINlWZ6dw6kNPe+4XD7Gg8ffIBAMgftC+O5vfQIAHUOgYrGIxcVFly/3jGAw
+      iEDAnXGtE5RSEEIgSd5Jo7xuw6TbZ4yBcw6fz434yxmnNvS845FYHHPzCyDUgmkY6BYshMPu
+      BHUCwbjp+QbQVBmmzXHj7bdh8O7e7/XYTSDwip4OEJ9ZwCcz/Sc8GHOWIgkErztiPYBgqnHF
+      AUKhkBtmBIKx44oDeJkeEwi8xBUH8HoSSSDwChEDCKYaVxwgGBxVOSkQXA4906CHe1s4quhI
+      +CxE59axvuws4RXrhAWTSk8HWFpewXH1Oba2DrHqiyOdCMOyrI4xv67rnsYBjDHP7QPwVAox
+      jjZMsn3O+ek/XuHUhp4OsLP1Cv7QDN5+24dQKoVoNApVVTv0Gj6fz1MNh9cakeZCHi8dwOs2
+      vAn2Oedjvwc9HeDtm992/Lx95Zff73d3NdgA5/TC/pvQhkm13+z5x90GV9zNS68VCLzElSdX
+      iOEEk4rougVTjSsO4GVwJBB4iSsO4OVKIYHASyZiUbxA4BUiBhBMNSINKphqek6EHR/u4bCi
+      493VGZTMINYXnSvtCjGcYFLp6QCzi0vI5J/h7r1nCM/cwkIqAkppxwIYTdM8XRTDOffUflML
+      5KUOxes2vAn2vRZVOrWhpwPsbb4A80fwrQ8/RUX2Q5KkrpKBSZ6Gb9qe5Da8CfY552NvQ08H
+      uP7+h7h+8t/zJ3WvTNPsGPN7XVTKa/vNH36S2zDp9hljkCRp7G1w5WyiMJZgUnHFAbys5ygQ
+      eImoCiGYakQCXzDViMJYgqlGDIEEU40ojCWYakQMIJhqek6ElY+PkKvqCHEDkfQyluedtUBi
+      PYBgUunpANHEDNT9Z1i9fgU7RwUspBNdNRvj0HF4bf9NaMOk2h9HXaDmec7T0wEy2y9gkRC+
+      evQV3vrgU5im6SiG83oDNcaY50Ks8//2Aq/bMOn2x/HwO7WhpwPcuPUxbgAAbrcYad9NUZIk
+      T3dY5Jx7an8cm+R53YZJtz+OTfKc2uDKHffyhxEIvERUhRBMNa44gGEYbpgRCMaOmAcQTDVi
+      CCSYakRhLMFUIwpjCaYaEQMIppqeCXzGKBoVQxgkyQ9Jcl6x7/VKfoHAK3o6QP7wAE9ebcNv
+      aAjOr+O7nznvGCMWxAgmlZ4OYJsq0vOLMIt5+HwSFEWBaZodleA0TfN0YTxjzFP749iex+s2
+      TLr95j1oFinzAqc29KkMt4aoDYTeWkcgFEMw0Eh3tmd9CCGeZoIsy/LU/ji0QF63YdLtj0ML
+      5NSG3nLoeBJRzy5HILh8RGEswVQjCmMJphpRFUIw1YiJMMFU44oDiA0yBJOKKw7gZe5WIPAS
+      URhLMNWIGEAw1fScCKuXjnD/mz3Q2iHmb3yMj25edzxOrAcQTCo9HSAxOwc/fwUSTMDQ1a5a
+      oDdFhyK0QJdn/7XUAgF+fPTxJzDUGiKpBcTCjZ6+vcenlE60DkVogS7f/mupBQIkJBJxJBJx
+      zy5KILhMRGEswVQjqkIIphpRGEsw1Yh5AMFU44oDeJk9EQi8RIjhBFONKIwlmGrE2EUw1bQl
+      8DnyRxlQXwQri3Ool7J4/OoQYa5j/up7uLoy72hEFMYSTCptDmDiH375BZauv4eVxTkkZmfB
+      jJfIlSsw/AnMJSOOWiC/3/9G6FCEFujy7L8WWqDcwT78keg5fb8ftz74Fky1hvDMImKxRpEU
+      oQUanknX6kyFFmhp/RrSL/cwt9Ac6kiYm5sF5mZ7GhYrwgSTSkeXZ+oqDEtUeRBMB20OwKDq
+      Fgr53FBGRHFcwaTSFgRLWFlfhy80nPxZrAkWTCpS+/8q1QIQGG5mVxTGEkwqbQ5gY2tjD8eF
+      48u5GoFgzLQMgUq5At758AMk55wnvLohtECCSaXlDXBwkAOxbSyuLA9lpDmJIRBMGi0OcPXa
+      GhZW12Br2lBGRHVowaTS4gClQgY7O4fQ9MYKL61ext0HX6OQ2cCLnfylXKBA4CUtMcCNmx+h
+      XLkDejKzG4wmYSglPPzqGKH0bawvxBy1QJIkvRE6FKEFujz7r4UWCCAIh8MIBBof+3w+fPad
+      f4RIKAjT4giFnOsC+f3+idahCC3Q5du/LC1Q2x23ICsWAv6zi4hGoiCS//Thd8I0TVcvVCAY
+      F20O4IdpKKjXlaGMiDSoYFLp0AIVj7KoqsNlgYQaVDCptDgA5xzJ+QXAGm5II7RAgkmlxQHK
+      +QJC0SCCYbE7sGA6aHGA2aV5ZPf2oRvDvQHE/gCCSaUjBuAIIBoZTt8vFsULJpU2B/DhretX
+      hp7wEGlQwaTSMREWikTAgmJII5gOWhzg+DCDTGYf0cUbAAClWsDdxxtYSYWh8Ag++/CmsxGx
+      P4BgQml5cpVqCTyUwMpCGgAQS80jgGeIRCJIz6513SMM8FYRKrRAb779y9ICEd5HzF+plFDK
+      5xFJL2FlIQ1FURCLxVqO2dvbw9WrV92/4hOEFujNt/9a1AVyYmZmFjMzvesCCQSTitgfQDDV
+      iP0BBFON2B9AMNWIsYtgqnHFAYQUQjCpuOIAojaoYFJxxQGEFkgwqbjiAGJFmGBS6TkRVi9n
+      8XQzC6KVEVm8hg/fvzGu6xIIxkJPB4jPzMLWXyEciEGt17pqgcQeYf2ZdK2Om/YZ51B0G4nI
+      mSxhFC1QWTGRjvWfixqgLlArhPjx/vs3YSgVRGdXu+4RxjmfaB2K0AKN135ds/DNkYzvvb94
+      +tlFtUA2ZfjmqI7Pb/WvZ3sBLZCEhYV5YKF3tWixP4BgGKqaiWzNnclTw2bI14wLf19MhAnG
+      jmzYKMgXf2jPoxg28iPYElogwdiRNRvZmgHGRi+rX1NNqMbFy/K44gBifwDBMBRVE4ZNoYzw
+      4DYpKCZqun3hZ9AVBxD7AwiGQTVs2IyjpIw+DKqqJkzKYNoXm4sSMYBg7NQ0CxIhyLkQCNc0
+      Cxy48DDIFQcQhbEEg8I5R0W3QAgZKXvTpKw2nKmgXEyOI9SggrGj6o3e2o1UaF1vDL8V/WLD
+      cCGGE4wVDqB64gCF+mhvAMo4ylrjwa/rng2BGB58+Sts7B5e6AQCwXlMi8I4CVhLqgnDuvgk
+      qmbaoJSDEHLqCMPSv6IVo6hWZfBoXdQFGoFJ0up4ab8sGyA4kz7kKipWZsIX0gIVahpsxuGH
+      hbpq9Lw+m3JHxUJ/ByA+XLl6BfGF5dN6QO1BbygUmhgdihNCCzQ++yVNQcAvgRACzjlKqoWr
+      C4kLaYE0W4VEOGbVQ2haFH6/v2sndlRVUNdM3L6Sbvm8/x0nEt65eRvLc6muhxiGO9Pagjcf
+      WbdbHtJRAuGyYsLPbUjcBi3t9dyopaQYyDpkncQ8gGCs1M6N1QkhIwXCikkRYDoAAlXT8c2z
+      Z12HUMey6ag/EoWxBGOl2pauzNaMC8sYfBJBgJoAIbAoR7FYwu7urqO9qmriuN75thFiOMFY
+      kbXWYUpJMUBHEMX52VmvbjOOvb09FAqFjuMKsoljufNcrjiAiAEEg8A5R63tDaDb7HQya1hk
+      zYSPNeagCAFMm4EQgufPn6Ner7ccW1IMaCaD3HYuoQYVjA3GAdloTUUGfBIy5eG25W1SrtVB
+      Tp49iRAYdsM2YwwPHz7E9vY2KKWwKUNFs8DAcdwWc4jBu2Bs2JRBb5v4amiCLpYJkutyy/83
+      FaHNLNPe3h7u3buH3cMcOACCznO54gDhcNgNM4I3HMNm0BxmfnMXzATVFa0x9jnBoq0jEUII
+      DMPAkydPkDby8IF2ZIJc2dtIaIEEg6AaNhgH2qe6nLIz/TAsCsWimDn3mUWdU6C6xRC0VcxR
+      DaVjgPO107fEAG8AjuzBDko1tesRojCWYBCqqglJ6pypLStW14e3GzXVRIi19uZWl0UxTe0R
+      4QzV3D4ePXoERVHAOR/AAZiJrx49Qb5QHOoC30RE9YvRKKkWfA4OoJjDL4/MywZCaB15mJQ5
+      JmQMm572+IbNUa5Ucf/+fWxubg6iBfJjbjYFwzC7iuF8Pt9ECLG6MagY7t69e3j33XeRSnWX
+      hXRjUsRqXtqvKrrjaIGyhiguHowPPJqo1mRIzAYnZ324TQHKGKS2+6hbFJzzk0AYUAwLiXAA
+      BwcHg4nhvvPd77d81C6KIoRMhBCrG4OI4crlMgzDwMbGBj755JOhA/9JEat5aV+xmONvTAhH
+      Xrbw3opvYDGcrqkAkVo6LQ4Ojtb7yBiHdSKZBucAAXSbI3VyjCtZoF4ipDcBzjkODw9BCIFp
+      mnjWQ3Mi6E6ty6IVQgiOh0yFGprS8RnjDdnzeSjnHZ/p5tlQVswDDIBpmigWiyCEgBCCWq2G
+      jY0NMQE4JEqPVVv5IVOhdVlpSYE2MduCad2iOH8UIaQlFSu0QAOQy+VaHnZCCLLZLI6Oji7x
+      qiYLzjkqPVZtHcsG2IAdCmMMstz5BiDozAQZFuvwk2ZMAAgpRFc008ZxTUe+qmFr7wCaSWHa
+      Zz0HIQSbm5uoVqtjv7Zu6b7XGYuy03SkE5pFoZmDZdkM00RV6UzLE0I66gPpFu1Ibpg2Az15
+      Zl2ZCHvTCmNxzvFnX+7hyWENIaoibWTBQeCTCD66MoOgXzo97unTp/jss8/Guk3Un9zZwT+5
+      vYy1dHRs5xwVzaSwGQPgnGljnGAjJ+Oz6/1/x3KlCptyxzmFjiGQ3elUjAOmxeAPSSIGcKKq
+      WtjIywj4JcSZDIk0Hn7OOXaLra9ey7Lw5MmTsc0RUMZwWNXxn3613aFsfJ2p641qcN0gBLiz
+      NdhcU7FcRTdHap9QM6zOt45EAMVsxCOuOIDf78qL5LXhNztFUM4hMRshqp4GW4QQlBUT1bZV
+      TbIs49WrV2MZCtY1GzXdgmzY+OM7u0PPoF4WimGh20PbZKeoIlftrwwtlKtO8S+A1uEh59xx
+      2EUIgX7iGGJFWBuUMvxmpwxCCMJ2rZE7PgchBLsFpSVgawbFh4fel47J1TTY7CQGOVbws68P
+      JyIGq6gWHEYsLRBC8GWftwDnHKVKreuk5fkOwWa862IbbZg3ALMNyGr3NNWbJIZ7ka2joloA
+      5whbdcdUm25R5KqteetmUFypVDy9vp2CeionkCSCX20WcX+n5Ok53aCqWQOVnXmwV2lJNrSj
+      6zoUvfuzaFF+2iHYlHXNLA3+BuAcz77+Ei+3sn0PfRO4u10EIUCQavCx7hM3mbLmWJH4m2++
+      ga67s/uJE0dtQwSJEPzlgwPsl7qLFb1imKWMveYAzqNaFF/vd+9EZFnuWUyLcX4aa+gO4/8m
+      JmWgjA+SBaKgDNA1rasWiHP+2utQetHsMWTDxtNMFUQiiBhl8MYfnb8DYLcg4+3FeMvnpmni
+      8ePH+Oijj1p6PDfawAEclFTHWeg/vrOLf/d77yIe9iYea79+2bDxp3f28K+/f91R4NZOUTF6
+      zp43f2YC4ItXx/hoPel4Ddvb2zBt3nXYx3mj+pyPAOrJMKd57Pn7yRigW/ZgYrgPv/ODlo/a
+      NSGRSOS116H0oqkFuveyCMknIUQ1BJnuOPw5T1m1IBsUyUjrtamqiu3tbbz33nunTuBGG2qq
+      CdmkjjFX3WT4k7v7+LefvwO/z/2Y7Pz1U8bw5/d2sV3WsFlQcXttps+3Gz17r1iRcw7OG8O6
+      g6qBomJjeSbS8vfnz59D0zRYjPcYTnHYnEOSJFiUtwrj+Nn3ODhMexA59AB4+cofFzZluL9b
+      BgEQM0t9H36gMRTaaQuIm597ERQflFX0yvnslTX85FHG1XO2wznHTx9lsFlQ4JMkfLE5WOpS
+      HqJ4LSEEX2yeVXbgnOPg4AC5XA6U8b5bK1l24+9Gj1hCIgSKaYt5gCab+TpKqoWwLcNPB9el
+      OAXEgDdBcaai9UwkEkJwZ7uEu1sFzzJD93dK+GKrdNqzbh7LKPXZpI4yfloRelAe7Z8Fw+Vy
+      Gdvb25AkCTbjfSUTzdjMaQ7gPLpFRRq0yRebRfjI4L1/E0IIDroExEAjKHajbAznHJmy1jeT
+      IhGCv3qYQabsflC8X1TwVw8zLb8P48C9Plko3bSH3hBPtxm+3q9A0zQ8f/789HPLZuhliRAC
+      8yT700t6ATSCZCGGQ2Pm90VORsSqQeqS+ekF5xx7RcWx123OFLshnz4Y8KHmIPjP/7CD+gVL
+      hjuhmhT/5dc7aFMWN4YrW8WevXKly1LIXhBCcGfzGF8/fgLdMGFTBps2FtX3s2RRBqvL6rDz
+      6BZ1Rws06YWx7u2WQcARtSpD9f5NCCEoKSYWdbsjIG7OFG9ubuLWrVsXLsGuGDbKqo2Af7A+
+      q27Y+KMvdvBvfudtBIYMivf29jA7O4tYLIaibODLrSK+3CrCoM7Bp2JSfJOp4lvrzsFwVbvA
+      ehHOUcvu4+8P5I4/9XUAm8HsM/wBGotlXHGASZiJ7AZjHPd2Soha1Ubvf8EHlBCC3aKC22up
+      jiV5hBDkcjmkUimsra1dyP5eUYHfN9zQbKek4qePMvgXn64P7HiNxT9H2M6W8UqPYyMvg598
+      3m2oSwDc3S7h9lrK8TxDa5Y4R8SqImTLF7ofJmWOIrh2CCEiCH6ZraGqGoiYF+v9z6OZzgEx
+      MHpQfFDqP/5vRyIEX2yVcH+n1LeT4pxDtyh+8dUWfvMqi7vPdvAq35gJ73deQgieZ2tdh1y9
+      1gE4EaTa0LHYeSzKe06CnWeqC2NxzvHrzSLiVgWkZ2g1GGczxN17n6dPn14obZypXCyolSSC
+      v3hwgP1i5wISoPEb7B7L+K939/Dvf/IUd568gkk5JM4aPfDA55Hw9y+PHf9W1weTQQCAj1lI
+      6Pm+w5xeUMZhOKwDcGIgB5BrFehm93HcpK4HqGsWXh2VELFrrtlknGOvpHbtcW3bxtOnT4eS
+      T1PGcNTlzTIYBH90Zxc19UyzpVsU97aL+MO/2cAf/mITD/crALMRtE8cjRBErE4xYC++Pqg6
+      ZsMGnQMgYEjqWUh8dGn5oJvmDbRJXqV4jK+fPO96xKTWy7m7XUTMqgx1k/tBCEFRNrvegGZQ
+      /PLly4FjJ1m3UTkfSA56vZwDnAG8UYH5T7/cQaGm46ePMvgP/+sZ/vzeAQ4qOiSJnKhfWysq
+      +6kBP+shdDxnH5yhopl4ma2eZmya/wy6gV3CKMB/Uu9/FM7r/fvRPwjmHNubr7B687e6aoFs
+      2544LRBlHA82swhZNfDmC9clRyAAdgoyPlhNngbEnPOWVGg2m0UkEhkoKN4r1ME4AxhB2JYR
+      taqohJfAyNnta7cfoDpmjFyLnZrM8R/3d6FFFk4/O8vPc4TNWof+KWRWYYbmO+wTzjGrZzp6
+      6//9txn8ZXwN50UGqsX6pm6iVhVhu964Fy7cB//JAqbzOGm7BsgCSfjHn/8QhEjwnaTT2jUt
+      sVhs4rRArw6rMCs5RIh0+qO4uUukbjHk6yZWT/QsjHXWxNnd3UUqlUI6nXYyccpRzUSIUCSM
+      AgJ2Qw2aNnIoR9aAk8JQ5+1LzMaMkYfEWWtvSoAkk0FoBHqgVWwWtFX4eGcWLEIVqGQe9Hy9
+      Hc6RMnLwM6uzt6YmgkoO1fDy6d+kPmnYoK0ibpYA9A+4B8XnZId3pnEH2CSPwO/3nz78Tkza
+      EIhzjocbGUTYxerSDwIhBEcVraceBegvn6aU4jibQVrNIEBPqiETAj81kTAKnb0lZ0jquUbP
+      7PQQEIK4UWjYOv0OR9iqOR5P2oNhzhEzy41YoYv9oK0iapYH6sklZiGh5/oe5xVTWRirqpo4
+      2N8beazZD8o49nsExIQQUEodg2LOOarVKh48eIDjo4OTLNX53pwgbNURsarnv4SEUUSA9lay
+      EgBJLXc66y1xiiDtkmVqBsMnhKjSeLh7/XaEIGaWG8tJe8EZUnq28aa6JKZyHuDxZgaS7V3v
+      36RfQNxElmW8ePHi1FEsy8LLly/x8OFDlGtyR2WzcydA3Cyd9uZhu9a1J29H4hQpPXva+5Me
+      vXUzGPYxEwk9P1jHQQgSev50C6MOOEfSOHYl6B0FV2aCBxmfN/TeFwtu2gOwUWAceLax6emu
+      8OdpBMQKbq0kQEj39ufzeSQSCQQCAWxubcGyGrnzxmLyXnCktCxqwXkkzOLgDxMh8FMDCeMY
+      Qar1/V7UrCDIzYajDHgOwhlSWhblaGtQDDSC3pB1sZleNyF8yKdSUZTTHeObHB0dYWVlpef3
+      ytU6/uL//OpC003cIXi5MJyjrhotP/yg1aEvfspGDZtOPRgBzv0iEiEnorKzzykboP2cN44n
+      BP2VMk7fRd8HkXMGAjL8A8s5OJHOMm0ntMcoXt+D5jna7Y+tMBZlDDVFO81aDIOrDgCMvdch
+      hIAxDt5x3rZCruCOn/dtOyEnhY8v0K6Bf4sLPPwn9gl450z7Jff8TaYyBhAImgzgABS//Plf
+      497jF12PeNMKYwmmh4GkEOFoCtTsnqsedFMDgeB1Y4CuO4Brb60jMrPY9YhJXxAjmF6GygIp
+      igJd1zvkz6VSCbOzsz2/a5oWdg8vNuNn2TYCHg6zmilWL9c2e92GSbfPOAdnzNPRhFMbXEmD
+      On3mJl7bN00TXu9zNum/kdf2bdsGpdTTMvNObXDFAQSCSWXkd9rO4we4s5PHv/pnP+pYCzsS
+      nOOn/+3PcO2dW3j58gWisyvgjOLHP/zdkVYLNaG2gf/5s/+HK4szyNYU+E0DjNkoWQH80x//
+      CKnIqG8Dhl/+9U+QmF3BviJhltSgWjaM4jFufO8P8MHa8FuttnO4t4WnG1sgtgZTBRTCkE6m
+      wCDhh7/3g5F/p/LxEe49egJDrePGzZt4fu8hIgvLqOs2/uU//9HIOXRqyPgf//1nWLyyikpd
+      QYwwGLqGmkXw+e//GIuJ0d4GnNn49d/+DDaPosTDWApbUCmFns3i2m//EN++vjj6PACHhETC
+      /Z1KOIAPPvwIR/t7SCUTgBRALOLe69HnD2E2nYIUCCEaDiAaT4IwhlQq6dKyAAkL8/OILl5F
+      HDJIIIqgnyCZTA5dI6cbhFMsLa8ilkgBjCKVjEMKhBAJuzOU8/sIEulFfOvb30Yhl0EymQAg
+      IR5z634TvPPWIsoKRywSRDSebGiUXLsHHKvX3gELhDAXNGCTEMIBCYlk4mwCfNQhELNNlKoK
+      5mbT7k7ucY5quYhgLAm5VkMqEYViUKRTCddOoaoqfIRBswhga4jEk6hW61iYn3OlLYamgkgS
+      qoqOaICA+0LQlTrS8/POevUhqZWLUG0g7OOIxJOoVetIxEIwKEEqMfowVVNqKNVUJCIhSKEo
+      dLmGZCqBmqxjfrZ/PdB+cM5QKBSRTMSgGhQSMxGKJlCv1TA3P993P4EBzoBSoYBYIoGarCEW
+      8oGSACxNRnJ2Dn5JEjGAYLoRU7iCSyW79QLBlXcQsuuwLRVbBypuv78OWdVQKpQxF5PwbPcY
+      7958D+GAD6ZFkU5GcffuQ/z2p+/j4UYeK3MJRCJBSL4gDF1DMhGHotsIEAOZbB0337/e9fzC
+      AQSXilotgy1yZF4+xd7hEWzTjyeP7yOSSOLKyjJiXEImc4RMdh/zsQDM2DX8/ndvwzB0wDax
+      s/UCj7/SsbiURNBSoVkEpbqO2fk5RAM2guGlnucXDiC4VGZX17G5+QLxaBrv3u41rDkAAABJ
+      SURBVJxF6biGT6+soFTXsJieQSJE8PFHcVBmIej3IRifByE+vP3ODSAYw/ryEpI35xCJBiHZ
+      OrgUhGkYMJiEEDT4InM9z///AQpr6gTut+9CAAAAAElFTkSuQmCC
+    </thumbnail>
+    <thumbnail height='84' name='Max Stop Process Count' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAABUCAYAAADUKzhSAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAAVh0lEQVR4nO2ce1zPZ//Hn9sn+RUVIhbdJUWr5FuJpJlN2J3d7c7SvTZa7qKcT4ucNoY5
+      ZKWEHCLJsha2NiYyTDqfVEw06pf6qWRrqBUf/f7oS25nC9v9+F7Pf+r7+Xy+1/t9HV7X+7qu
+      Pu9eamxsbEQgUFFe/rMdEAj+TIQABCqNEIBApRECEKg0QgAClUYIQKDSCAEIVBohAIFKIwQg
+      UGmEAAQqjRCAQKURAhCoNEIAApVGCECg0ggBCFQaIQCBSiMEIFBphAAEKo0QgEClEQIQqDRC
+      AAKVRghAoNIIAQhUGiEAgUojBCBQaYQABCqNEIBApRECEKg0QgAClUYIQKDSCAEIVBohAIFK
+      IwQgUGmEAAQqjRCAQKURAhCoNEIAApVGCECg0ggBCFQaIQCBSiMEIFBphAAEKo0QgEClEQIQ
+      qDRCAAKVRghAoNIIAQhUGrXHPXDmzJkX4YdA8KfwUmNjY+Of7YRA8GchlkAClUYIQKDSCAEI
+      VJrHboIfy4UvmTJnNxW9vNiwxBndZ+DUvZTt9WdGTAlggc/GTxjWHqj7kRUfhpENGHoEE+ja
+      tYVWZEoPfs7KHZlU1quh2X0YMxd4YaUFXC1k79oMDOeNxqbFtQEyQnEPTGr+rKbJK/b/Zv6k
+      QehJz8LA80KmMnUHG6IPc6qyHlprY+rowzQf++fjt1xJ6pZdVL89lREP6l65lL3z5xCjP4PY
+      qXZ/yESLI8CF9CQqAApTSKtuaWmP4xTZ+XUA1GUkk/0si65LYVdkJreclhAT4YdZ6X6CY08B
+      UJa4hZjcK8jP0h6GeATHEhsbw+ZJCn5LCmd7St0ztfCsqcveyPygE7T3CCE6NpboQHe0UoOY
+      H3nqGbeNkuxdBB0upeEBt+Sa0+z97FNizt9skYmWRQA5j0MHKmjjOBjz1KN8n3gB5391B+pI
+      CvQmtHIUwYGudKWInRPnsc/Mnx1TzTgVuZSggxdoUDfHUfEbR5ON8I+dyqM13JGOHS+Tl1uA
+      PMiGgtw81AwN6VJSorx/lTxlubU3W6NtOYpP5rvQ7sQKfMPysJq8EX/9eKbP20cbj5UsczXg
+      PyatmitU325LrUEEfDGo6feMUGX0KSHQvRSP4ECcru1lw9o9ZFbW01rblCGTZjPGWgdJObOb
+      2TlyJS+JSvQYMnU5vnZaj6iXhM7AgViHJFNadQUyduMemIRhz55cOlvBkMWbGaObypbPwzl2
+      oRY0X0HhPoPpzkao00Dx/jWsjsmksr41en3HMGfWMAwkmcrULaxcd5jS+tbo9R3JlAmu9NKq
+      41T0IgL3N7VR8/NQdngVyyMfEP3u8AvHvz1Kjc1kxg3sgDpAl2EEbBvW/MjVQvZuWMuezErq
+      W2tjOmQSs8dYo3NpL/4zYkAZqTNC3QlMcmzq84xQ3AOLcRjehaKjmVRigLP/Irx0E/FXRsmY
+      Ge6U+sfSPMmXEb90ETG/GmPcsYbzjxw3j6ZFEUA+lUrK9TY4DvFlsL0aFUnpXABAA9sB1qiV
+      JJNeBhSlceJyGwYPtoG8GIL3V6KYtJkdm7zQLbv4hNbaYGtrwc2cPM5whrycm1gpFM2D+FQs
+      wceMmBYZS8wSJ9QLotmbDVqDxuFlAdk71vDZxm+oNh7FJJd7Bj9Alzd411GHy/sWM+njSE5c
+      /L1pVrObSrCHIeCIf2wgrh2SCF8cw7mek9gcE82St2QOLl9KfFlzUaWtbFkWGc0Sp5c4HBxO
+      0iMndpmaEyfIQQ29Th3uXL1uOobImHW83/MCcUuCOPbS23wWHcMGvx6ci1xMeEYd8qkdLIv8
+      CZNJEcRGjKNb7hZWxV2A6gTWBp3Ecm40sdELsCuNYUVMHvKlQ+yIv4D2O6uIWetO+8xIdqXU
+      Adl8E5FJpWIa0dH+9K/cz+b9F+7xs4gzp6CjgT4aD6xHHUnhi4k515NJm2OIXvIW8sHlLL27
+      YR7KRcrauhMUuYQRWqXs/+IIl7q6EujvyO1Iee8KR91gCDOXTaJ/myco/hG0QAB1pCQc5XpH
+      J163kLAZPJg2FQf4oWnVgMaA4QxuU0JyehkXslK53MaRgVYSl34+x3X6YG+vg6RuhEP/bk9s
+      sYOVFYbXs8j9Ppes6xbYKDSbb1qMYfksIwrXL2bm8gQu37mhy7DJXlhczye/xJCRk1wweOB6
+      VQu7qesInT0K8+uHCZn5b+bvLb0/tBdkk3GzG8Nd7dGR1DEa4YwVTfW8jfXAgehI6vQyN4Wb
+      OeT99CB7JcTMcMfd3YNx63LRcw7Az7F5aJmZ90KS1FG/lEtmBfT7pytG6hI69s4M7nidpJQC
+      Lp09Qw3WDLTXUkatWNb+qzu/ZGVQyGW+XzQa99EL2VcB18/9zKVOPTDVgUu7Z+M1P5W2Iycx
+      pp8GYIhJLzVIC8FrfCSV/b2Y8NbfnrhflA1DdsZNug13xV5HQt1oBM5WUJKczuMl0I3+Dkao
+      Syb06gnI8mOWVF0ZMdUXe72Wn+H88SVQXRYpOTfh5jfMc//mzuWkE3l4WVghSRbYD2hDYvZu
+      vv21gs5vvYkFPEFjPAL93ig6xnDgiwPUG47Eoh0cUt6qPricmVsuY+83lQVvn2TVvNg7X5Mv
+      lXLxJsBlLpbVgsHDliTqdOnrytS+LvRb40HQV99y0nUinZ/SzVuyDPfHmHswxCM4kBbv3bnF
+      g809uHyv1St49Yfv2JeQzck9Icy93o5t3hYMmxuE/uED7E5MouiHSBZVqLHxk2G0v/NNE8ws
+      IKm0nDpMHhIFHoIkIcEjBrWE9PLdP18cf9hc9ZEEMm525t2VscTGNm3m/B3VuH70KNkygITV
+      0LfoXJhEUkVnHPt1B6BLD1PacJLU1BrkhmKS05qXQGV7/XF3DyXjoVZNUNi2ob6+no6K3tzd
+      t5dKi7lJFyztjFH/36JmoclF7ApP4LrxO7xjU0/yxghSr95fspwRyvvuY1mTehXky1RVA7q6
+      dw2AW8iyjGxmg53aRRL2plIjN1C8bz95asa81q/Zm5OpTfcKT58DNWusXn3q5m2mq4K+nSH9
+      670UN8jUpO7n6GUdBjta0qWnGTqcJDXjKjScZttEd8ZuykPb1IzOlJCcUop8NZU1Y92Z8uUF
+      uPAl08ct4EedD/l03VyGd4T6+nqoSyLQayobKwcw9/NgxvYB6n6n/j8cac9r/xiMTvYONp+4
+      QgPQcOkHAse5M259NnVYYmOnxsWEvaTWyDQU72N/nhrGr/Wja5dX0AcuV1UjNxRy+tzTNICM
+      fEtuEvlz4A9GgGrSUgqh87soxzWgXAYlHeVoyjjsHDWgez8cO+9m9/+8iaPyOcnKgxnOhQSG
+      jMNLry+DTbpBycPs3I+ZlTVqCTnYKkyA/ObrwzxQZEQS7u2FXl9rerWBM2cLKTobxjfVxnjM
+      fg9XzU4UTdnCxgh7LKbbc3cckOzGEuBcQeg6b9zrobVeX3zmuNEdkHvbYbAnjiCPS4wOXYHf
+      J1VsWB/OBI9aJG1ThgUE4NIVKG8qy+TlAuZ7hTRt6AL8cHyq6fJeuuO2cCa/hmxh4ehYZM1X
+      UPh8jK+NBhJefOxTzcp13rjXt0bb8l0CPKyQtCyY7VPC6i/m4BErodfXhzlu3UH6G7N9Sli5
+      bRwe4WpodncmYIwNaIBfQBFLgxYzet9NZd1H0OUeTzRsfFk2cwcboqcxOuT2MehMlvnYoAE4
+      +n1C1Yb1hE/woFbSxnRYAAEuXYEuOLsZkBG3FK+8Idi9Ak1Hh4/B2Br7DqnEzhpDZcAXTHwm
+      Z9D30PiiyVrX6DHKq3F9dn1jY2N946mtExpHeW1pLHjhjjwH0kMaR40a1RiS/mc7InhSWv6H
+      sKelzz/w6lvIF4GjOXITWmub4jzDHYsX7ohAIN4GFag44l0ggUojBCBQaYQABCqNEIBApXns
+      KdDvv//+IvwQCP4URAQQqDRCAAKVRghAoNK0/C/BxXF89HE8laajCV447LmkRJbHzycgrhQw
+      wzN0Hk7tgLokgnw3kQsYuK1gmYt+C63IXEwMJXhXDlUNEpqGTkye8wGWbYFrZ4kPz+JvH3mg
+      aHFtgKxwPEOSmz9LmnTpNxr/8Y50+ounRFal7yLiyyOcrmoAdS16DPiQiV79no/fchXpkXH8
+      8vcJDL+ne68V7GRlWCIltTLqnQbgFTAexz/gRIsjQHFmKpUA59LIeu4pkWfIK1CmRGalk/ss
+      i65LI25nDrfeXMC29d70vJhA2O7TAJT/sJ24vJpnnPZngNuKKKKitrHWtze/pUSwM+0vnhKZ
+      G8HisBTajVpFRFQUEUvfRSsjjMXRp59PSmTubsKOXbznrVSAIr7dnECV7XQitq1mZLsUIrYe
+      59c/YKKFKZEFHEmsRNPBEbO0JA4eKWaYmxFQR/KaiYRXubJimQv6nOfLGYs40GsaW/x68dPO
+      lYQlllDf2owBvX8jKc2IaVF+2D7SmC66utXkF5xGdlRwuiAfycCAzqWlyvvXKFCWWyuro2U+
+      krn+zrRLCWLKpnx6j1/LNP19zFl0gDZuS/jYpdt/vkJ/9Vd+ud2LbR2Zuc2x6fescGX0KSXE
+      sxS3Fct481o8mzfGk1PVgLpWD94YP533+uggKWd2U5sB/FqQQhWdeH3CYrxt2z6iXhI69vYo
+      1qdRevkXyNqOZ0gyBiYmVBRV8sb8MN7rkE5k6FaSSmpBswtWIycxeZghrbhBycEwQmNzqGpQ
+      p5P1e8yY6kQ3SaYqPZLgTce42KBOJ2sXfMe50LNtHadjPiP0YFMbNT8P5UeD+Tz6AdHvDr9y
+      Yn8SvynG86F9B1oBdHmTmeFvNj9y7SzxmzcSn1NFg7oWPd4Yz/T3+qBTEc/8gDhQRuqscE9C
+      kh2a+jwrHM+QYvoP6cz54zlU0Y3h0+fxQYcfmK+MknEBnpRPi8LvzgAxwSMkCg8A6tBuA3L1
+      b9QC7R45hu6nZSmRP2WQVqvJgEHevNZfojI1k2IANLDu1wepNI3McuB8BqnVmgxyVEDBV4Ql
+      VNHbdy1b1n6Abnn5E1rTRKEwQ84toJBCCnJleltZNQ/i07sJO/43JmyKYtuCN1E/vYvvcqGt
+      44d8YAa5u9axOmIf1d1dGTei2/35I3qDcHHQpvrAcmYu3UlqWV3TrGbrxwo3A8CBaVHLcGmf
+      zJblcfxsOp612yJYOPQWiZ+vYt9d1ShrZc3HGyNY8OZLHAvbQvLjUiJTU8lFolPH5uyDWpP3
+      2LgtGHeTYvauDCPp5bdYFLGNNf825ufo5URk1SGf/oLA6EKMx68nar0XXfOiWLO3GKoPEx5W
+      wKsfRRAVMRvbsjiCvipArjzCl9+XoPX2EratHkm7nJ3EpdUBuXy3PYcqq4lEREzHtiqByAPF
+      9/j5M0VnQLfrw1Mik7csJ+5nU8av3UbEwqHcSvycVfuepH/LKW87khUbF/CW1kUSvvqRSn0X
+      lk1z4Hak9HvI7Hgtazu7ckHq1PGu3I0np0UpkWmJP1Kr+wavmUsoHAehWZnIsaZVAxr9nRik
+      WUpaZjnF2RlUaw6gv6VExfkiaumNnZ0OUitD+ts9+dq9vaUlBrW55B/MJ7fWDKved3WF+fss
+      mmrIuU0rmBt0iObVmC5Ovh9gdv0Up0oNeGfcCLo9cKnYFlu/YFZNd8Ws9gjr507k0/iL94f2
+      03lky/o4vd0PHakVhsOH0pumet5GYW+PjtSKnr1MQD5JQeGD7JUSF+CJp+dYpmzMp9PwWfg4
+      NNenV6+eSFIrWlXkkVMJfUf8A8NWEjr9hvGabi3JGaepKDrLbyiw79dWGbWiWO1mxK85mZyj
+      mkOfeePpvZQDlVBbdJ4KXSOMtaHim4X4Ls6gjYsv79lpAAYYm0qQuZ7xU3ZSbTcan6EGT9wv
+      yoYhL1tG3+lt+ulItDIcztDeUJqWyeMloI9df0NaST0wMQFu3uRJ/tfDjZKvCQxL5jepO65u
+      /Z8uS01JC1Iic0g/KYO8j0We++5cTkkrYLS5JZL0Knb9NTlyMp4DNZXoOb2OOTxBYzyCVyyx
+      0o3jUOwhGgxcMG8HR5S3qhMDmRt1hf7efvj/vYA1i/bc+ZpcUUa5DFBNWXkddHvYkqQVXWxc
+      mGAzAtt1Ywnbu598l/HoPaWb8hOlRBrgtmIZLd67Iz8kJfLB5Y9etphexw6QcPgk+fHrWXRd
+      m/APzXHyX47+kcPEH0mm6Fg0n1W8TOg8p7uWFD0wMYPksnLqMH66waamhho8YlBLvHw7JfJJ
+      97Hl+1m6aA8XZG0cpvnj8uBZ7bH88ZTI44fJlvVw+TSKqKimzdw0B4naH5PIVaZEWr7hhN65
+      ZJIr9bDvawRAZ2MTNMknI6MG+UYJaRnNkiiPn4+nZzhZD7VqTG+FJg0NDehaWXJ331aU/S8y
+      erxq2x310vPNQpPPE7f1MNe7j2CEop60rdtJv3Z/yXJWOGM9/ViXfg3kai5fAXQ73DUAZGVK
+      pBU2UjmJ36VTI9+gJOEQ+VJ3BvZt9iY/I4Ma+QZnC4tA6oNlr6dt3bvQt8JaDzL3fUvJDZma
+      9IMcr9bG0d6cziY90SafjKxrcOMMO2Z44retAC2TnuhRSlr6ReRr6azz8+SjuGIojmPOlE9J
+      1nmfBUEzGaoL9fUNUJfMmvGz2XrZjlnLVzLGEqhvuOf/8bRjoLMj2rm72J56hRvAjUvHWDPZ
+      k8mbcqnDHCsbifLE70ivkblRksChfInuA/uir9eZV4Dq6ivIN85SWPQ0DSBz676UyGoSI7/i
+      gqxJ/8kr8HvkHuvR/OGUyKy0c6DngnJcA8plUPKPHE/7EFsHDTDqi71ePPGtB+GgfE6yHMXk
+      4edYs34Kvp2sec1YH0ofbOVB9LJUIB3ORdHbGChovj7EDavsnURM9KWTdR9MNaGw6Bznizay
+      r7o7btPdcNHQ5eePoti63Q7zSf24u9kk29HMGl7Bhk0T8WwA9U7WeM5wxQiQLWzpFv81YWMr
+      eW/1YnzmXmbzlq1MH1uLpNUDp1mzcNYH/q+pLGPpFJ/6rm/a0M3ywaFFKZFGuM6ZTM367Szx
+      3oOs2QUrzwC8FRpIjCbA8wrBmybi2aCOlrkLM0dZIrV9lemepYTGLWTsHolO1p7McDUCyYDp
+      nqUE75jC2AgJTcPhzHpfARrgM+sCK8OW431AVtZ9+H2RT0PhzSeTdxHx5Wy8198+Bp3MJ14K
+      NAAHn7lc3ryFrdPHUitp0cNpFrOc9YHODP1nNzK/XoVvwev07QxNR4ePq7oVdu3T2DPPh8qZ
+      2xh/+wy6Mo3jZ2SglrSwiaQBGLgpD1yejscmxDzzd4FyNzE2KBuHWWsZ1wfO7JjNZycUBIR/
+      iPmztfTiUZ4COUx7+KZN8NfixadE9nbmA+si4tZ4c1wGda0eDJ/87n//4Bf8V/LiI4BA8BdC
+      vAskUGn+HzFSCTrHLo6pAAAAAElFTkSuQmCC
+    </thumbnail>
+    <thumbnail height='76' name='Missing Paths' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAABMCAYAAAA7rrikAAAACXBIWXMAAA7DAAAOwwHHb6hk
+      AAAL/klEQVR4nO3df1RU553H8bcdQg6MiD8ARSEjRsWKjgOImgSTdnUl1a49WHtbjCRYkZiK
+      VEyIGq2JUSOKQqDG4CrrmCC4YzZUd7VqYzYqikr4IUpEpRIktIooAWQIZsbsH4CgglZG6x7u
+      9/XXcO9z7/fec+bD89w790eXH3744QeEUKkfPe4NEOJxkgAIVZMACFWTAAhVkwAIVZMACFWT
+      AAhVkwAIVZMACFWTAAhVkwAIVZMACFWze9wbIGxVTkZMNOmlgE84G9+eQA+g/lAsr6zPBXSE
+      JMQR3M+WGtkkKXFk3vrbDkf3Mfx28Ryed9M8+HoCYzBFBdyjWRJKXCagJejtLcz0AShm2+/e
+      YmclEBiDKQqSlDjKQhKI68DOZScpxJWFSA/QqRTmcqoeoJ7so7kPffW6kARMJhPpm+ZgqMkk
+      eWsW9Q+9Smt15OQXN34sPs6RytbzAogymTr05QcIiDJhiguWAHQaLi64UED+aStYT5NfYIdO
+      59Eyv7YA44IwpikKSmg47+4qw4qV4m1zUZS5bCu2UnsolmnKLJKya+9ZSuP8HM/5gqXiCtfI
+      JklRUGKWsCRUYZbxDNSeJWNNJKFNtRYb86i2tlpB5RckRYaiKKFEJh2iwtp2HRcXFyrzT1EO
+      lJ/Kp1KnQ3drbmPdmIxyoJ7C1AWETVMa17lmP2VN6yw/sIbIUAVFmUbYAiMFTbuWnaSgxGRI
+      ADoNrT/+PhbyCoqgqIA8ix6DoWV4UmhK4GD/32M0pbN8vD2nUzPIRcPA38wmyPkyuze/R/yW
+      XLSBEcwIcLpnKWv1EY7kgZ2bKz2bJ9YNItSYzgfTPMhMXkb6+cHM2ZRO6vIXse5fxYpd5S0r
+      KHuCUas+JnX5eLpkJrM1q+1+ZIi/P9rSAgqrqigsKMXFYMCzrYaX/sLHu0ro9os1pP9RoceX
+      RrZn1QO57Ez5kgrD70lNjWF0xR427Sm5bVEJQKfRE71eR11OPn/Oz6HOxw+DY8tcn9BVvN7/
+      LBuWzWfVvlZjCY0PYfOC0F44RSHPMnNGAO19/UvTo1EUhZBZH5DvNpGFswNxaJ45ZCjeGg32
+      9kXkZlvwCApmjLMG+/6TmKiH0qMnuBUB3+cY4wT23kMZhIW8gjNtF/TR42tXSO6xY+QWavE3
+      DG67nevTDHKGS//1JmGLj9F1yhxCRzkAOgZ628HxRMIijFSMDuO1F5+6bVEJQCfSd7gBl8q9
+      pO2tRKf3ofutOVfZv2o+7+6pQD9tCUum6G5b7tvyb6gDqCvnm2/bGY/QcgxgMqVhXB2G/t4d
+      he00wzDooSAtjQI7X/RD2mvnQ9jaWOaFBPKUXTknP01k0ceFQC8mLIpn6YyJePeqo/hzI++8
+      f4CqVotKADqTgQb8tQ00NLhgGN764PASZV9boM8wAgbYc7G41XCk9hCbjIVoA3/Jv/YuxZSU
+      cWv83DHD8Auw45t9GRyrtnLj693sKbBjwNhR3NqivCMcqbZy4+xXnMcOX/2P21mXA8P9fLA0
+      NGDRGxjW3gmnkv9k3qwlHHJ+hXc/WESQCzQ0NEB9JnFhUWyseIZF6xKYMQKo/46GVovKadBO
+      ZQh6Xzv25fljGAicapk+IcRAtjGZmWFujPT1RksR54prqf8kmVxtIDEzfo3fxeucWGYiKWM0
+      sVM9eZATnC0cCJz9Nlc+3EDyayGYNd0YNGEhCyf3A/7W2GTgjzi9OIzECnAbF83sQId219bD
+      R4+OQrr6DceB4rYbeU3lzfBSVm+ZRUiyHY5eE1kY6gcOMHthMSvilzF9t4Un3UYSvmASfYCy
+      pkW7yE3xQs1kCCRUTQIgVE0CIFRNAiBUTc4CiUcmO0khLvP2aboOXrz2gJXvuHgPmi8KHHUi
+      huh0T2JMUfTNiJEAiEdMF0JCXDCP+ivfduk2whYchym48WM50gOIx6E8g5jodOoGDObmxXP0
+      m5nCW8ML2bwumYMlZnB0x6BEM29if+yb2nYfP5Frh/dQhhvjpoyj+sCnfFkBbuOiWPVq+5dv
+      3F26VQ+AHAOIR600nWhFQVEUFCWJ7FazKp3+hbi0VBaMreST5fEc7PJz3ktN58PZT3PeuIzk
+      7JaL5IrNQ3jHuJxJThUc2HGWkSuNfBjWn4oDJj4rv6tqU+noproKSlJ2m22kBxCP1j2GQLqh
+      3jhhD1fy+fIyjJofTH97DYyZyE9cMtmZdZqoXza29X1uDE6acrppAa033s4aerm60vKbblul
+      73+8IT2AUDUJgHj8+hkY2RtO/CmDr29YqT62hy8qnflJ4LBHXlqGQOL/AS+m/mE+3yZu5g/T
+      TVgd3TGEL+VVPwdoZ3z/sMjFcELVZAgkVE0CIFRNAiBUTQIgVE0CIFTtvqdBi4qK/hnbIcRj
+      IadBharJEEiomgRAqJoEQKiaDdcC1VJgXEH8/hLMlidxC5zF0jnP46aB2gIjK+L3U2LW4DYy
+      lAWvT8Azt/mZ7608xruFRGdmJjv5DRI/r+QG9jj9eApLl05B1/pJX9ZSdq9ea0MPcH4nG/ZU
+      MDomtfGJvJnJbPyiCq7uJz72IO6zN5L+3ot0yU/DdKQWAqKanitpIv3tIJxxJlAZL19+8fBd
+      +192fd6bl1NMpG98iafO7GDnHa9LuLZ3MzuemGpDDzBoOsmm6Y2f653RYuFqjZmqnCwKLb7E
+      jHFCw0v8Me2l25ezFrM9eR91fpH3fQy3EB3y179S7DGUCCfQMIyhHlbO1ZiBlsdl95y0HOOk
+      h3IMUEv2po/JxQ43156Y666DSxV/eT30rpcVANRnZbD7cm9+8evn/+H7OIV4IBYrdz7f9+q1
+      q202tTEAN/j6k5UkZFZjN+BX/OaZpoecVlbSLyKl6WUFm1nzSfNLCao4fCAbi/fPGO9lW2Uh
+      HoRG0/Zgx6YAlO9aylumC1icA4leHIynBhy1XYFBDPW2R9PbDz8dXL7c9EKG+lPkFoLObwS9
+      bCksxL307ElPq5WbrSb1dXe/u5211IYAXN3P5u0XsGifZX58FM3D+R7+AXiTx5FjtVirC/mq
+      FHSefRtnXjjPWezw0smhr3iEBurRV58k9+9WrFVnOPd3Dzw87mhTm8fGN97v+EHwpSOfU2gB
+      LEeJn3kUaL4LP4i588tYl/wqIWYNboGRLJ3c9IU311FHP9x7d7SqEP8AjS//FvI/rJgfQrrV
+      HpcX5hDlCZBFgnKMMaZoHNMSOVBulmuBhLrJL8FC1SQAQtUkAELVJABC1SQAQtUkAELV7vs7
+      wHfffffP2A4hHgvpAYSqSQCEqkkAhKrZcEvkdU5vW836z0oxW+1xfSaMhRGBuGpaTceRPqOm
+      ExMRiGvz7WjXc0hemEjZhFhWTu77UHZCiDvVFm0nIWEfxfUaeul/RXR0EE9pbmvBya2xNvQA
+      xf/Npn1X8J+Xwpa1U+ielcJ/HP4W8tNY1zx90fN8n5XCtuON73r6/tIx/v3d9RytsW3nhLgn
+      60m2v38S74Ub+WjLWn5+cwc7jprvaLKdD4v0NvQAA0NI/Cik8XN9N7RYuVpjBnct2tsaaunR
+      3R7IIeXNDRz38sKTkrvXJ8TDciaHnAFBxHvZA/aMe3Mz4+5oohkxi+QRD+UY4Do5W7eTjwZX
+      lx7grTDvZ904vG4mM1bs5eYLEShDNYAGZ/1UFsVMxtP2okK0y1xZCU+Ws2NBOC+/HE702n1c
+      vPMeySY2BuB7Sv8Ux/qjNWi8gpk62gHrV2m8/+ebvLgkhS3vTaHrwQQ2Hq0HDIS8MZnBXW2r
+      KMT91NTUYM6/QK95G/ho82LGXN3G1s+q2mxrUwD+tmcF73xagrXbs0TGTMZDA5eLz1HDQLwH
+      P4HGwxNPrOQWfGVLGSEeSJ8+faDPMHzd7cHeC69+cP78+Tbb2nBL5GcYd5RgdRxNZOxs/Jv+
+      s/dwcUVDMWfPfY/1mzLK0OAz5OkOlxHigQ0bwYgrOZy4aIUbJZSUaxgyZNBtTcyH1xGemNXx
+      g+CK44cpsgLm46z/3XEAPKfGsnJyOK+XrGb9qpnsxRHdC6/x27HdbdofIR6I41gi5l4gdmU4
+      GfUaegW8wqKf9gBOsP7lE4z6KJJRYyOYeyH2/rdEyrVAojOTX4KFqkkAhKpJAISq/R8EJTMz
+      yEBrXAAAAABJRU5ErkJggg==
+    </thumbnail>
+  </thumbnails>
+</workbook>

--- a/tableau/Performance.twb
+++ b/tableau/Performance.twb
@@ -1,0 +1,1279 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<!-- build 9200.16.0303.2316                                -->
+<workbook source-platform='win' version='9.2' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <preferences>
+    <preference name='ui.encoding.shelf.height' value='24' />
+    <preference name='ui.shelf.height' value='26' />
+  </preferences>
+  <datasources>
+    <datasource caption='ft_output_performance' inline='true' name='textscan.0y9arhp0wpcoxz1gzwqa10sxglpy' version='9.2'>
+      <connection class='textscan' directory='C:/Users/lzorn/Documents/fast-trips-stop_order/sfcta/demand_v0.1_stochastic_iter1_nocap' filename='ft_output_performance.txt' password='' server='' username=''>
+        <relation name='ft_output_performance#txt' table='[ft_output_performance#txt]' type='table'>
+          <columns character-set='UTF-8' header='yes' locale='en_US' separator='&#9;'>
+            <column datatype='real' name='iteration' ordinal='0' />
+            <column datatype='real' name='trip_list_id_num' ordinal='1' />
+            <column datatype='real' name='label iterations' ordinal='2' />
+            <column datatype='real' name='max stop process count' ordinal='3' />
+            <column datatype='string' name='time labeling' ordinal='4' />
+            <column datatype='string' name='time enumerating' ordinal='5' />
+            <column datatype='real' name='time enumerating milliseconds' ordinal='6' />
+            <column datatype='real' name='time labeling milliseconds' ordinal='7' />
+            <column datatype='real' name='traced' ordinal='8' />
+          </columns>
+        </relation>
+        <metadata-records>
+          <metadata-record class='column'>
+            <remote-name>iteration</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[iteration]</local-name>
+            <parent-name>[ft_output_performance#txt]</parent-name>
+            <remote-alias>iteration</remote-alias>
+            <ordinal>0</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>trip_list_id_num</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[trip_list_id_num]</local-name>
+            <parent-name>[ft_output_performance#txt]</parent-name>
+            <remote-alias>trip_list_id_num</remote-alias>
+            <ordinal>1</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>label iterations</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[label iterations]</local-name>
+            <parent-name>[ft_output_performance#txt]</parent-name>
+            <remote-alias>label iterations</remote-alias>
+            <ordinal>2</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>max stop process count</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[max stop process count]</local-name>
+            <parent-name>[ft_output_performance#txt]</parent-name>
+            <remote-alias>max stop process count</remote-alias>
+            <ordinal>3</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>time labeling</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[time labeling]</local-name>
+            <parent-name>[ft_output_performance#txt]</parent-name>
+            <remote-alias>time labeling</remote-alias>
+            <ordinal>4</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <scale>1</scale>
+            <width>1073741823</width>
+            <contains-null>true</contains-null>
+            <collation flag='0' name='LEN_RUS' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteCollation'>&quot;en_US&quot;</attribute>
+              <attribute datatype='string' name='DebugRemoteMetadata (compression)'>&quot;heap&quot;</attribute>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>4294967292</attribute>
+              <attribute datatype='integer' name='DebugRemoteMetadata (storagewidth)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;str&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>time enumerating</remote-name>
+            <remote-type>129</remote-type>
+            <local-name>[time enumerating]</local-name>
+            <parent-name>[ft_output_performance#txt]</parent-name>
+            <remote-alias>time enumerating</remote-alias>
+            <ordinal>5</ordinal>
+            <local-type>string</local-type>
+            <aggregation>Count</aggregation>
+            <scale>1</scale>
+            <width>1073741823</width>
+            <contains-null>true</contains-null>
+            <collation flag='0' name='LEN_RUS' />
+            <attributes>
+              <attribute datatype='string' name='DebugRemoteCollation'>&quot;en_US&quot;</attribute>
+              <attribute datatype='string' name='DebugRemoteMetadata (compression)'>&quot;heap&quot;</attribute>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>4294967292</attribute>
+              <attribute datatype='integer' name='DebugRemoteMetadata (storagewidth)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;str&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>time enumerating milliseconds</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[time enumerating milliseconds]</local-name>
+            <parent-name>[ft_output_performance#txt]</parent-name>
+            <remote-alias>time enumerating milliseconds</remote-alias>
+            <ordinal>6</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>time labeling milliseconds</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[time labeling milliseconds]</local-name>
+            <parent-name>[ft_output_performance#txt]</parent-name>
+            <remote-alias>time labeling milliseconds</remote-alias>
+            <ordinal>7</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='column'>
+            <remote-name>traced</remote-name>
+            <remote-type>5</remote-type>
+            <local-name>[traced]</local-name>
+            <parent-name>[ft_output_performance#txt]</parent-name>
+            <remote-alias>traced</remote-alias>
+            <ordinal>8</ordinal>
+            <local-type>real</local-type>
+            <aggregation>Sum</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='integer' name='DebugRemoteMetadata (size)'>8</attribute>
+              <attribute datatype='string' name='DebugRemoteType'>&quot;double&quot;</attribute>
+            </attributes>
+          </metadata-record>
+          <metadata-record class='capability'>
+            <remote-name />
+            <remote-type>0</remote-type>
+            <parent-name>[ft_output_performance#txt]</parent-name>
+            <remote-alias />
+            <aggregation>Count</aggregation>
+            <contains-null>true</contains-null>
+            <attributes>
+              <attribute datatype='string' name='character-set'>&quot;UTF-8&quot;</attribute>
+              <attribute datatype='string' name='collation'>&quot;en_US&quot;</attribute>
+              <attribute datatype='string' name='field-delimiter'>&quot;\\t&quot;</attribute>
+              <attribute datatype='string' name='header-row'>&quot;true&quot;</attribute>
+              <attribute datatype='string' name='locale'>&quot;en_US&quot;</attribute>
+              <attribute datatype='string' name='single-char'>&quot;&quot;</attribute>
+            </attributes>
+          </metadata-record>
+        </metadata-records>
+      </connection>
+      <aliases enabled='yes' />
+      <column datatype='integer' name='[Number of Records]' role='measure' type='quantitative' user:auto-column='numrec'>
+        <calculation class='tableau' formula='1' />
+      </column>
+      <column datatype='integer' name='[Time Enumerating Milliseconds (bin)]' role='dimension' type='ordinal'>
+        <calculation class='bin' decimals='2' formula='[time enumerating milliseconds]' peg='0' size='500' />
+      </column>
+      <column datatype='integer' name='[Time Labeling Milliseconds (bin)]' role='dimension' type='ordinal'>
+        <calculation class='bin' decimals='2' formula='[time labeling milliseconds]' peg='0' size='500' />
+      </column>
+      <column aggregation='Sum' caption='Iteration' datatype='real' name='[iteration]' role='dimension' type='ordinal' />
+      <column caption='Label Iterations' datatype='real' name='[label iterations]' role='measure' type='quantitative' />
+      <column caption='Max Stop Process Count' datatype='real' name='[max stop process count]' role='measure' type='quantitative' />
+      <column caption='Time Enumerating Milliseconds' datatype='real' name='[time enumerating milliseconds]' role='measure' type='quantitative' />
+      <column caption='Time Enumerating' datatype='string' name='[time enumerating]' role='dimension' type='nominal' />
+      <column caption='Time Labeling Milliseconds' datatype='real' name='[time labeling milliseconds]' role='measure' type='quantitative' />
+      <column caption='Time Labeling' datatype='string' name='[time labeling]' role='dimension' type='nominal' />
+      <column aggregation='Sum' caption='Traced' datatype='real' name='[traced]' role='dimension' type='ordinal' />
+      <column caption='Trip List Id Num' datatype='real' name='[trip_list_id_num]' role='dimension' type='ordinal' />
+      <column-instance column='[traced]' derivation='None' name='[none:traced:ok]' pivot='key' type='ordinal' />
+      <layout dim-ordering='alphabetic' dim-percentage='0.451064' measure-ordering='alphabetic' measure-percentage='0.548936' show-structure='true' />
+      <style>
+        <style-rule element='mark'>
+          <encoding attr='color' field='[none:traced:ok]' type='palette'>
+            <map to='#1f77b4'>
+              <bucket>0.0</bucket>
+            </map>
+            <map to='#ff7f0e'>
+              <bucket>1.0</bucket>
+            </map>
+          </encoding>
+        </style-rule>
+      </style>
+      <semantic-values>
+        <semantic-value key='[Country].[Name]' value='&quot;United States&quot;' />
+      </semantic-values>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Time Enumerating'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='ft_output_performance' name='textscan.0y9arhp0wpcoxz1gzwqa10sxglpy' />
+          </datasources>
+          <datasource-dependencies datasource='textscan.0y9arhp0wpcoxz1gzwqa10sxglpy'>
+            <column datatype='integer' name='[Time Enumerating Milliseconds (bin)]' role='dimension' type='ordinal'>
+              <calculation class='bin' decimals='2' formula='[time enumerating milliseconds]' peg='0' size='500' />
+            </column>
+            <column-instance column='[time enumerating milliseconds]' derivation='Count' name='[cnt:time enumerating milliseconds:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[traced]' derivation='None' name='[none:traced:ok]' pivot='key' type='ordinal' />
+            <column caption='Time Enumerating Milliseconds' datatype='real' name='[time enumerating milliseconds]' role='measure' type='quantitative' />
+            <column aggregation='Sum' caption='Traced' datatype='real' name='[traced]' role='dimension' type='ordinal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]'>
+            <groupfilter function='member' level='[none:traced:ok]' member='0.0' user:ui-domain='database' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />
+          </filter>
+          <slices>
+            <column>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style>
+          <style-rule element='cell'>
+            <format attr='width' field='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[Time Enumerating Milliseconds (bin)]' value='91' />
+          </style-rule>
+        </style>
+        <panes>
+          <pane>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <style>
+              <style-rule element='pane'>
+                <format attr='minwidth' value='-1' />
+                <format attr='maxwidth' value='-1' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[cnt:time enumerating milliseconds:qk]</rows>
+        <cols>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[Time Enumerating Milliseconds (bin)]</cols>
+        <show-full-range>
+          <column>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[Time Enumerating Milliseconds (bin)]</column>
+        </show-full-range>
+      </table>
+    </worksheet>
+    <worksheet name='Time Labeling'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='ft_output_performance' name='textscan.0y9arhp0wpcoxz1gzwqa10sxglpy' />
+          </datasources>
+          <datasource-dependencies datasource='textscan.0y9arhp0wpcoxz1gzwqa10sxglpy'>
+            <column datatype='integer' name='[Time Labeling Milliseconds (bin)]' role='dimension' type='ordinal'>
+              <calculation class='bin' decimals='2' formula='[time labeling milliseconds]' peg='0' size='500' />
+            </column>
+            <column-instance column='[time labeling milliseconds]' derivation='Count' name='[cnt:time labeling milliseconds:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[traced]' derivation='None' name='[none:traced:ok]' pivot='key' type='ordinal' />
+            <column caption='Time Labeling Milliseconds' datatype='real' name='[time labeling milliseconds]' role='measure' type='quantitative' />
+            <column aggregation='Sum' caption='Traced' datatype='real' name='[traced]' role='dimension' type='ordinal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]'>
+            <groupfilter function='member' level='[none:traced:ok]' member='0.0' user:ui-domain='database' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />
+          </filter>
+          <slices>
+            <column>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <style />
+        <panes>
+          <pane id='1'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+          </pane>
+        </panes>
+        <rows>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[cnt:time labeling milliseconds:qk]</rows>
+        <cols>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[Time Labeling Milliseconds (bin)]</cols>
+        <show-full-range>
+          <column>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[Time Labeling Milliseconds (bin)]</column>
+        </show-full-range>
+      </table>
+    </worksheet>
+    <worksheet name='Time vs LabelIters'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='ft_output_performance' name='textscan.0y9arhp0wpcoxz1gzwqa10sxglpy' />
+          </datasources>
+          <datasource-dependencies datasource='textscan.0y9arhp0wpcoxz1gzwqa10sxglpy'>
+            <column caption='Label Iterations' datatype='real' name='[label iterations]' role='measure' type='quantitative' />
+            <column caption='Max Stop Process Count' datatype='real' name='[max stop process count]' role='measure' type='quantitative' />
+            <column-instance column='[traced]' derivation='None' name='[none:traced:ok]' pivot='key' type='ordinal' />
+            <column-instance column='[label iterations]' derivation='Sum' name='[sum:label iterations:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[max stop process count]' derivation='Sum' name='[sum:max stop process count:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[time enumerating milliseconds]' derivation='Sum' name='[sum:time enumerating milliseconds:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[time labeling milliseconds]' derivation='Sum' name='[sum:time labeling milliseconds:qk]' pivot='key' type='quantitative' />
+            <column caption='Time Enumerating Milliseconds' datatype='real' name='[time enumerating milliseconds]' role='measure' type='quantitative' />
+            <column caption='Time Labeling Milliseconds' datatype='real' name='[time labeling milliseconds]' role='measure' type='quantitative' />
+            <column aggregation='Sum' caption='Traced' datatype='real' name='[traced]' role='dimension' type='ordinal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]'>
+            <groupfilter function='member' level='[none:traced:ok]' member='0.0' user:ui-domain='database' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />
+          </filter>
+          <slices>
+            <column>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]</column>
+          </slices>
+          <aggregation value='false' />
+        </view>
+        <style />
+        <panes>
+          <pane>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <color column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]' />
+              <size column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:max stop process count:qk]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='false' />
+              </style-rule>
+              <style-rule element='pane'>
+                <format attr='minwidth' value='760' />
+                <format attr='maxwidth' value='760' />
+                <format attr='minheight' value='335' />
+                <format attr='maxheight' value='335' />
+                <format attr='aspect' value='0' />
+              </style-rule>
+            </style>
+          </pane>
+          <pane id='1' y-axis-name='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:time enumerating milliseconds:qk]'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <color column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]' />
+              <size column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:max stop process count:qk]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='false' />
+              </style-rule>
+            </style>
+          </pane>
+          <pane id='2' y-axis-name='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:time labeling milliseconds:qk]'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <color column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]' />
+              <size column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:max stop process count:qk]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='false' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows>([textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:time labeling milliseconds:qk] + [textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:time enumerating milliseconds:qk])</rows>
+        <cols>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:label iterations:qk]</cols>
+      </table>
+    </worksheet>
+    <worksheet name='Time vs MaxStopProcessCount'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='ft_output_performance' name='textscan.0y9arhp0wpcoxz1gzwqa10sxglpy' />
+          </datasources>
+          <datasource-dependencies datasource='textscan.0y9arhp0wpcoxz1gzwqa10sxglpy'>
+            <column caption='Max Stop Process Count' datatype='real' name='[max stop process count]' role='measure' type='quantitative' />
+            <column-instance column='[traced]' derivation='None' name='[none:traced:ok]' pivot='key' type='ordinal' />
+            <column-instance column='[max stop process count]' derivation='Sum' name='[sum:max stop process count:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[time enumerating milliseconds]' derivation='Sum' name='[sum:time enumerating milliseconds:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[time labeling milliseconds]' derivation='Sum' name='[sum:time labeling milliseconds:qk]' pivot='key' type='quantitative' />
+            <column caption='Time Enumerating Milliseconds' datatype='real' name='[time enumerating milliseconds]' role='measure' type='quantitative' />
+            <column caption='Time Labeling Milliseconds' datatype='real' name='[time labeling milliseconds]' role='measure' type='quantitative' />
+            <column aggregation='Sum' caption='Traced' datatype='real' name='[traced]' role='dimension' type='ordinal' />
+          </datasource-dependencies>
+          <filter class='categorical' column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]'>
+            <groupfilter function='member' level='[none:traced:ok]' member='0.0' user:ui-domain='database' user:ui-enumeration='inclusive' user:ui-marker='enumerate' />
+          </filter>
+          <slices>
+            <column>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]</column>
+          </slices>
+          <aggregation value='false' />
+        </view>
+        <style />
+        <panes>
+          <pane>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <color column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]' />
+              <size column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:max stop process count:qk]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='false' />
+              </style-rule>
+              <style-rule element='pane'>
+                <format attr='minwidth' value='760' />
+                <format attr='maxwidth' value='760' />
+                <format attr='minheight' value='335' />
+                <format attr='maxheight' value='335' />
+                <format attr='aspect' value='0' />
+              </style-rule>
+            </style>
+          </pane>
+          <pane id='1' y-axis-name='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:time enumerating milliseconds:qk]'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <color column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]' />
+              <size column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:max stop process count:qk]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='false' />
+              </style-rule>
+            </style>
+          </pane>
+          <pane id='2' y-axis-name='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:time labeling milliseconds:qk]'>
+            <view>
+              <breakdown value='auto' />
+            </view>
+            <mark class='Automatic' />
+            <encodings>
+              <color column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]' />
+              <size column='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:max stop process count:qk]' />
+            </encodings>
+            <style>
+              <style-rule element='mark'>
+                <format attr='mark-labels-show' value='false' />
+              </style-rule>
+            </style>
+          </pane>
+        </panes>
+        <rows>([textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:time labeling milliseconds:qk] + [textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:time enumerating milliseconds:qk])</rows>
+        <cols>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:max stop process count:qk]</cols>
+      </table>
+    </worksheet>
+  </worksheets>
+  <windows source-height='28'>
+    <window class='worksheet' name='Time Enumerating'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[Time Enumerating Milliseconds (bin)]</field>
+            <field>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]</field>
+            <field>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:qk]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+    </window>
+    <window class='worksheet' name='Time Labeling'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+    </window>
+    <window class='worksheet' name='Time vs LabelIters'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+            <card pane-specification-id='1' param='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]' type='color' />
+            <card pane-specification-id='1' param='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:max stop process count:qk]' type='size' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+    </window>
+    <window class='worksheet' maximized='true' name='Time vs MaxStopProcessCount'>
+      <cards>
+        <edge name='left'>
+          <strip size='160'>
+            <card type='pages' />
+            <card type='filters' />
+            <card type='marks' />
+            <card pane-specification-id='1' param='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]' type='color' />
+            <card pane-specification-id='1' param='[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[sum:max stop process count:qk]' type='size' />
+          </strip>
+        </edge>
+        <edge name='top'>
+          <strip size='2147483647'>
+            <card type='columns' />
+          </strip>
+          <strip size='2147483647'>
+            <card type='rows' />
+          </strip>
+        </edge>
+      </cards>
+      <viewpoint>
+        <highlight>
+          <color-one-way>
+            <field>[textscan.0y9arhp0wpcoxz1gzwqa10sxglpy].[none:traced:ok]</field>
+          </color-one-way>
+        </highlight>
+      </viewpoint>
+    </window>
+  </windows>
+  <thumbnails>
+    <thumbnail height='192' name='Time Enumerating' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7EAAAOxAGVKw4b
+      AAAMFklEQVR4nO3dWXMb2XnG8X83dmIHCJIgRWofaWYk2zOemmQ89uQmufJNqlL5CP5M+QRJ
+      pXLlsm/tC7sqqbKjGWodbaON4r5gIfYGujsXciYG4aJQCtGwcJ7fHZvFrrdUeHT6nPP2geX7
+      vo+IgSzLsuxpFyEyTQqAGE0BeEedRoVbt27x9PlLen135PeHOxus375Ds9sf636+32dnc5tO
+      fzB0ffv1Kzo9h5fPn7K5+ZqtvT1qteZb79fvHFNr9b7/+bhe4ahSp9s6ptv3wPdoNN5+n1ln
+      aQ7w7m794Y+Ul/Lce7yB7Q+YSyfZefYdN776OfUXtwnllrC7DY66LrlUgmSox3cvjohGIZ7O
+      sXtYZyGTpLyUZvvgkJ3ndYrniyQTKSJ+CzuxxKD6gli+xLNnGyQTUexMlmS7R9WOk7fqONE8
+      EdchW8hTafUJdQ+IzxWoHe7gxXKEk1n+4W8+5P7TFzy5e4+FpTL1nksulyOfjnPj4xvT/mec
+      Gs0B/p+isSiuO2BgRSgtLhILeWTyJTLJOLFYDHBptwYUiila9SpH9Qb5wjyl+SyN9oBzq2WS
+      mQz7O7vYkRipuE3PD1NIxnH6PVqtNpnSOfb3jri6WsC3wsRjUexIgl6jjh2dY2E+i+f6OE4f
+      x3GYyxSxB208K0Q2n6dZq+D7Hlg2kUiYXq+LH0qQiofQ/30aAf5qvXj6LbHcMsul3Jncr1at
+      ksvn/+yKT7V6TD6fPZP7v48sy7LeOQCDwQDXHX32FXlfxONxK/yuf9zpdIjH42dZj0jg3jkA
+      lmURiUTOshaRwJ0aAN9zaXd6xKJhBh5Y3gA7EiMSDgVVn8hEnRqAdqPG3dvr1HvQ8yEftvAT
+      af7uJ58HVZ/IRJ0aANuGQSRN2u4RcV2ikRheyKbVatHvj7fBI/LX7PQAhGNcWDtHLpum71mE
+      PYdwIsNcPKI1ZJkJ77wM2mw2SaVSZ12PSGC0EyzGUwDEaO+8D/DnXh62+Kd/+a+zuBXXl9L8
+      6y/+9kzuJfI2ZxIA1/c5ajlncStqHa0uSXD0CCRGUwDEaAqAGE0BEKMpAGK0U1eBmrUDvv56
+      HTuRITo3R7+yRyizyBef/SCo+kQm6tQRID6Xori4gttpUjnYJZYq4vXbaoaTmXHqCNBtN3EG
+      Az6+eZNG1yPut4nmlkgmk2qGk5lwagBSuRKf/qgEQCmQckSCpUmwGE0BEKMpAGI0BUCMpgCI
+      0RQAMZoCIEZTAMRoCoAY7a3NcLfvPeT6zR/y+OET4nQJZZf40UdXg6pPZKJOHQGSmQLFfJbH
+      99bZ2NxgEErRrB2qGU5mxqkjQKOyS63j8snnP+PCwS7dVoVo5qqa4WRmnBqAzPwKX8yvADB3
+      bgVYCaImkcBoEixGUwDEaAqAGE0BEKMpAGI0BUCMpgCI0RQAMZoCIEZ7azPcN+t3SRWXqB3X
+      SLg9QplFPv/k46DqE5moUwOQSGYolhYol0vsJ2M0j47pdY7VDCcz49QAdBo1Oo7L3t4+XjjJ
+      YilFNHtFzXAyM04/Ga6wyGeFxaBqEQmcJsFiNAVAjKYAiNEUADGaAiBGUwDEaAqAGE0BEKMp
+      AGK0tzbD3bn/mEQyRafvMkePcHaJm9cuBVWfyESdfjJctkgxl6LZcvD6dQb+HPWjPTXDycw4
+      dQQ4PtjiqOWyulyg0c2ToE0ke1nNcDIzTg1AdmGVLxdWg6pFJHCaBIvRFAAxmgIgRlMAxGgK
+      gBhNARCjjQTAdQc4jja5xAwnAuDym1/+O//xq98ymE49IoEa2gir7u/QC6cppZJY06pIJEBD
+      AcgvlFnIZ2i5bwYG3/d48O0jiuk4hy2XyKBBJFvm8lp5KsWKnLWRVgjf80hnMgB4/T5b29v0
+      M3EO2j1ycwWcxgvWyvN4nhd4sSJn7UQALCxcmu0uAKFojJXyIvEQ9MIucatHuriC7/tqhpOZ
+      cCIAPs22Q8er8r8f7xs3bgJw5cQfOo4z8eJEJu1EAGwuXb1Cxw0Rmk49IoE6sQzqsb+zy/7u
+      Ae506hEJ1IkAWLQrdaKZOS2DihFGAhCO+WxuHigAYoSRR6Buu00sGkeLnGKCoUnw8VGV7PIq
+      cTeuEUCMMBSAZn2f755vkEgvoFV+McHQI5BlRQjh0m53FAAxwvAcwHfo9H1KCyW9KCBGGHoE
+      SuXmuXxhDedPbQ6+2+e/v7nD6mKe/eYAq1MlnCnz0dXzUylW5KwNBcD3IVcoEom9aYf2fWg0
+      jnnerNGPxpgLp3EOtumcW9DJcDIThgKQKc7jfveMo6MjcsUS5fkMa6vnSMVCbNccklaHSPYC
+      sVgM19Vesbz/RrpBHacHtk2z3oD5DFevfgBAeW0K1YlM2Mj7AHPJJDZzXLq8Mo16RAI1tNjj
+      eS7VShVfL7uIIYYCUN3dYnNnjydPn6sbVIww9AiULS1SSM8xSBb1PoAYYWgECEeiXDy/gqf/
+      /sUQIxu+lUaPC6sL06hFJHAj7wN4bYeep2OxxAwjI4DnttncPphGLSKBOxEAn75lk4pE1Q0q
+      RhgJQKvZpN3pAOD2e6zfvY/rtHjw8CnbW1tsvN6cQpkik/EXjkX5gK2j9pufQhHq1UPuflPh
+      8esDLp6/RH/QpVjIqxlOZsLo0Yi+RzgaxQIs2+bSxYusrZ1ncXWbbrNCNLumr0mVmTFyMtzm
+      600ySxe/v7K29qb3f3llGVgOsDSRyRsKQK/jcPPTH9NsOZoEixGGAvD68VMqQAYYnPylyAwa
+      WgXKLeRwWg0arj78Yoahz/n88ioXugPsdFrNcGKEkZPhbv3+9/xx/b7aocUII71AS+eXiFqR
+      6VQjErCRneC241Eq5nQ0ohhhKADtRoNa5YCnz17qcFwxwtAkuHZQ4auf/yNh39IqkBjhxOnQ
+      +xweHZGKpbn5gwy2N2D9zn1K2Tn2m33iXptwZolrl1anVa/ImRoKwMqV61zJ576/6LoeR5Uj
+      fnjjOocPv6Xdi9Db3eTCygKDgV6akfff0Byg2zzg17/8NbfWH+ACoUiU1ZVlnjy4ixXJkowP
+      WCivEQqFCIW0UyDvv6ERoLR6icVnr6lXK9/3Al2//uFf/EPL0jqRvP9G3gdYOVem4cW1EyxG
+      GApA57jC1n6NWDyJe/KXIjNoaA4QS2Xwuk2cgaeNMDHCUABs28YOhUnE49OqRyRQI71AuWyG
+      RqMxnWpEAjZyLpBlWQz05RdiiJF3gqvVGp4X0SuRYoShAHiux/xCkUrH1jKoGGHoEWjz8UOy
+      q9eIDLqo0UFMMDQCFJeXWL/zNYlMkTBvzgh6+WqDVMzmoOES81vEsmXOLRWnVK7I2RoKQDK3
+      wE9/+n9Ho7t9hwcPH7FUKNByGiQieXqHj1hZ/EnghYpMwqmbvaFonOXFEtlEhE7dIkybWGGJ
+      TqejoxFlJry12+HTT38MwOUT1z19kZ7MgJF9ABGTKABiNAVAjKYAiNEUADGaAiBGUwDEaAqA
+      GE0BEKON9d779qtnHLY8IoNjItkyV87ru8JkNow1Auzt7rC7t0GjY7O79RLHcdQKITNhrBEg
+      k83hRFwSdMnMn9OhWDIzxgrA5es3Rprher3eBMoRCZYmwWI0BUCMpgCI0RQAMZoCIEZTAMRo
+      CoAYTQEQoykAYrSxdoIb1X126w6RQYNYtky5lJt0XSKBGCsA9+/ew0+mCQ9CdHcfUC59Oem6
+      RAIx1iNQoVCg0+6D1yKdm6fVaulkOJkJY40A125+wrUT13xf3yAg7z9NgsVoCoAYTQEQoykA
+      YjQFQIymAIjRFAAxmgIgRlMAxGhj7QQDNI4b9DrHRFNFMsn4JGsSCcxYAajsbvCf64+YT6fp
+      Wxt89eUXk65LJBBjPQLVj5s4nS79fptwNKFmOJkZY40AFz/4iPNXruP7HpYVwrYtNcPJTBh7
+      DmDbNpozy6zRJ1qMpgCI0RQAMZoCIEZTAMRoCoAYTQEQoykAYrSxNsKqB9vUuhbhQYNYrsxC
+      Pj3pukQCMdYIEI6n2d95xs5eg0cP7k66JpHAjBWAV49v0w/n8PrHJNJ5NcPJzBjrEejGZz8b
+      uaZmOJkFmgSL0RQAMZoCIEZTAMRoCoAYTQEQoykAYrSx3wkGaB7XCMWSJGKRSdUzdb97csC/
+      /eHVmdzr7z9c5J8/Wz2Te8lk/A8jwAMJopeDUgAAAABJRU5ErkJggg==
+    </thumbnail>
+    <thumbnail height='192' name='Time Labeling' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7EAAAOxAGVKw4b
+      AAAPgklEQVR4nO3dSWxbd34H8O97j/suUly0WLaVyHvi2JnYySQTZ2+K5jBFgRbtZVAURXvp
+      BrS39jQt0OXQ9tJLT+2pRYFiUHSmmTaDTCaTiePEkR3JlixZOylRFEVS3Mm39eDJ8iSNSdkh
+      afH//Zxs6v2sHw1++f+/5f+eZJqmCSJByb1ugKiXGAASGgNAXWBg9uZ1XJ+aRbFU2vPT7c0U
+      ynUNAKBWCsgUKl/8bHnxLqp11bJ9cukOssUqPrt5A5mVO1hcXMDPy+8rtb7+xZ8L+RySqRQk
+      7gNQN+RTC9jSvLj90x9A9UagOFyQdjaROHUJEVsJwbEnsL0wiVt3FqHbnHDZFFQNB8K2MvJ1
+      B4KRAbjMEpz+UXhQRbVRwcZOHRFtByVDhumJwmkzkVpOInH0GI6NRLCynEStUoPhDyHmklCp
+      VbCZLuDXv/MdLN25haW5adh6/R9DYnC4ffAbTgyPHYd/6Ah0zYBeCWMgHoZdlbCyMAfFsGHs
+      6BjKdQ2D4TAMmxNyPY+A5kI0GsTW2ixUyAjHhqDlc3hqyIVGIY+AKcHmG4RaKyPkC8Ib8MFU
+      ZEQGQpCjCXgiYZiVAjxqCH5vADABmywjGo1xBKDDwTRNbKXX4Y/E4XY8/Pe22mhAcTgfLACm
+      aaJcLkOWuQtBh9sDRck0TSiKAo/H83X3Q9RV/AonoTEAJDQGgITGAJDQGAASGgNAQmMASGgM
+      AAmN1wLRQ9ENE9eWcgequXw8DFmWOtTRwTAA9FDqqo7f/OerB6qZ/e6bcMlKhzo6GE6BSGgM
+      AAmNASChMQAkNAaAhNZGAAzcuvEJVpcX8f7V62jqRue7IuqS1odBdRXr6xtQF1bhHR3DTrUB
+      Hw+eUp9o/VGWZERjcfiDASS3Sgi4HJBhQFXVlqVEj7rWAZDteOoblwAAj03ce8kwJAaA+gJ3
+      gkloDAAJjQEgoTEAJDQGgITGAJDQGAASGgNAQmMASGgMAAmNASChMQAkNAaAhMYAkNAYABIa
+      A0BCa2tJ5MzsDLz+EPLFKs6dOYlH46Z2RA+v9Qig2OF3O1HYSGK7uINCTQWfrEr9oq0pUF2X
+      8fjjY2jUmnDKQK1W63RfRF3R1v0dHp+4txj4l18dBQAYhg31er1zXRF1CXeCSWgMAAmNASCh
+      MQAkNAaAhMYAkNAYABIaA0BCYwBIaAwACY0BIKExACQ0BoCExgCQ0BgAEhoDQEJrKwD5bAbV
+      Wg3J1AYMLoekPtLGovgaPvzZVQS9TuxIHngHBhF0KV1ojajz2lgSKcPlckDVDVSbNcimgWq1
+      AVnm7IkOv9YBUJx45Y03LS8Zhp1rgqkv8GuchMYAkNAYABIaA0BCYwBIaLsCYCKdWkEqne1N
+      N0RdtisATXz04cdYS270phuiLrMEIL22CtnhRrPZ6FU/RF1lORGWODIO940pSHZnr/qhLssU
+      6/jrt2fb3t7rsOG73z7XwY66a9eZ4Cay2xU8NmbvTTfUdaWGhv/8NNX29iGPvZ8D4ML5i2fg
+      Cod70w1Rl+3ZCV5fz2Jjfb033RB12Z6L4YLhQUgKTw+QGHZ90h3YTi8CDndvuiHqsj1ToJ1c
+      HbV6tTfdEHXZrimQgrHxUdicrt50Q9RllhGgXCpg7s5dFAo7veqHqKssAShsZRE/cgTBUOAr
+      rxr46IP3sLYwg++/8xPUVL3LLRJ1jiUApWIeM1NTWFr9yrVAhg6X04WpG9PweN0o1RqoVrmP
+      QP3Bsg/g8QZw7sJFxEbHvnxRUuDzB3D55ZeRWs8i4nNDgsk1wdQXLAGIJkawupZEpdb88kVJ
+      xmMnTwMAIuFBAIBh8N5A1B8sU6DVuzPI1yWE/J5e9UPUVZYR4NSFS/AOrMFUbNANE4os9aov
+      oq7YdSJMxY3rk7h29X2kNou96Yioi/acCPO67Rg99gRG44H9K4j6iGUEaDRqKOyU0Wg0IXP6
+      QwKwBGBzLQnYFDSbaq/6IeoqSwCGxo7C43Ij4OW1QCQGSwDsDhca5TzqvNqBBGEJQL1WguwO
+      olrM96ofoq6yHAXS1CaK+Sw8sdFe9UMC+qvvz6ChtT/t+OPXTiDsdXwtv9sSAF8ggmefu4xs
+      hZc6UPf827VVlBpa29v/zgvHv7YAWNcDFItw+oIwVF7oRmKwBECWFdhsNpw6fbJX/RB1lSUA
+      Hp8Hc7duI53hzXFJDLuuBZKgN2to6kZvuiHqsl0BMKBqGuo13hyXxLDrYjgTTc2E3+e1vLp8
+      +zoyRRWpXBlvvPoy3HZeJ0T9wTIC7ORzKOayWP7q8wH0BuYXFrG+uoFAKIBqo8k1wdQ3LCNA
+      cmUDz7/+Btwe/5cvKk688ktvodrQsJHeQsTvAkyuCab+YAmALCtwulxw2K23R1ccbvgdgN9/
+      LxiGyRNl1B8sARiMRyArDng8fEAGicGyD+C0y/jhf38P127O9aofoq6yBCAQDiMRH4ZscEEM
+      iWHXYVAHXnjlJcgynw9AYrB80vOZFfzv2+9gcnq+V/0QdZUlAAOxBCqFbUgcAUgQ8u6/DkYG
+      UOMxfhLErn0AGdFEAg1lz6PDiPrSnovhtrM5aGr7q3OIDjPLV73a0BCOBGAL8TnBJAbLCDA3
+      M4sTT15Evbjdq36IusoSgNHRIXw2OYlwbKhX/RB1lWUKFBwcwuVBfvhJHDzgT0JjAEhoDAAJ
+      rfUZL1PH1OTHcDh9WM7s4MoLz8GhdKEzoi5oYwSQEYsOYn5mFk63A8VanWuCqW+0EQADO+UG
+      Lr34PHxON8I+NzwePkWS+kPrKZCk4MTpswCA2M/PD/A5wdQvuBNMQmMASGgMAAmNASChMQAk
+      NAaAhMYAkNAeevHveqEG/QDnBeIBFxy2Ryd3+WoT5Xr7S0ADbjuCbnvrDelQeOgA/Oo/fYDN
+      YvsP1PjBH34LZ4YDD/trvzZ//39z+NcPV9re/o9encCfvH6igx1RN/H2Dw9pvVDDWq79a6Oi
+      fifGo74OdkQHwQA8pO/dSOFv377T9va/8cwR/M2vPdnBjuggHp3JOFEPMAAkNAaAhMYAkNAY
+      ABJa66NAhorpz6bgCwaQ3NzBpWcuwMbHBFOfaD0CSDaMDMewemceumRip9pAo8EnyVN/aBkA
+      01Bxa3YB42dOApqJgMsBReFtIag/tJwCSYoDL7x4BQAwOjYOADAMCZrGW6jT4cedYBIaA0BC
+      YwBIaAwACY0BIKExACQ0BoCExgCQ0BgAEhoDQEJjAEhoDAAJjQEgoTEAJDTeF4gOte1KA7/7
+      L9fb3t6uSPj333vui78zAHSoqZqJT1fzbW9vV6zreduaAumaCl3XUSpXYJp8QB71j7ZGgE/f
+      fxs2/zAWN3N47ZWX4HdySST1h7ZGgGgsBsVmgyTLMHSdD8qmvtHWCHDk1NOQJBkTJ5twuVww
+      TQP1er3TvRF1XFsBUJR7m7ndLgAAdwOoX/A8AAmNASChMQAkNJ4I67F3Zjbxdwd4wswzxwfw
+      l99+ooMdiYUB6LFiTcWdzVLb2w8FXR3sRjwMwCF3J13EP7wz3/b2IwNu/PmvnOlgR4cLA3DI
+      bZeb+J/pdNvbn0r4O9jN4dPzAPzpf9zE/AGmAH/x1hl841i4gx2RSHoegPnNEm4md9revniA
+      p7oTtcLDoCQ0BoCExgCQ0BgAEhoDQEJrOwCl9CL+64fvotrUO9kPUVe1fRi0XNiBz+9FQzPg
+      sj06SyL/8Z15XF/Jtb39bz9/HC+finWwIzpM2g5A/LFTyJlJBNy2R2pFzO2NHfxkPtv29m+e
+      G+pgN3TYtB0A2e7G2dMTUFUVjUYDzWYTpmni958fRbWxd1qkGzoUee9I4bfpqFQq0DQNNpsN
+      v/V0HG+cGGi7fsQnWerfOhPBk3F32/Wnow5L/ZXxAOLuY23Xnx/1WuovDnnwZ6+0Xz8R91nq
+      Hx+wH6h+ZMBtqY95cKD6Aa/dUu+WtPvUywCstxFx2mVUKhXoug5ZlqEZ5r71hmkAAGRp7yy7
+      Wa9BawCmaUKWZfzBlSNQNeuXqgkThmHs+x6cUL94D4qx//s3DB2SLEPa1b8sA5VKBYZxrz/J
+      fID7nBjGvTXBHo/noKVfqFQq8Hq9rD+k9fV6HXa7/YEfmq5pGjRNg8v14Fe3Psx7aDabkCTp
+      wQLweYkkSfv+fO7WTeyoCp556tx9/43d9YbewPvvfYDEUBybO3X45Brc4TGcfnysrfpbH78H
+      Z2wci7OzGIxHoRmAUc4hNn4O46OxlvXLs9dRd40gszSNaCyOTLGJgK0OZ2gUZyaOtqxfmp/B
+      ZqECrZyHNxBGtqIh7pNgugZw/sxEy/qNlbuYWy/AK9URjkRwdzWDWCQATXLg6fNnLd9l+9Xn
+      0yv49O4mIi4NpuLGVnoTidFRlGoqvnnpQsv6Sj6NDybnkYh44AtFsDQ7i9jQMNKFGl578fKe
+      emDXZ8A08OMfvYuh0RjyZRVGNQ9/MIJUtoyXr3wTTpt8/3oAH//0PQzEo9iuKbDXNiE7g9jK
+      ZHHpW1cQdFsnLLvfQ724hWvTSxjwOdDQTVRzWxiIxpHaruL1l56F8pVtP//9D3Qt0C/64H8u
+      mc7i3gDziwOw379h1IvYymSQyhbhDzihOtzIlxf2DcB+9XqjgvTqGmqNGq7PrOFo2IChO9FM
+      JvcEYL96yVCRz2WRy2SxmNrGwGAQmsMFlBb2BGC/eq9TRmYjBdlmw9RnVzF0+gySVRVORxnY
+      FYD96j0eJzKZLcT9MuZu3YZv+ChuLZQxNOACcLZlvT+cQKN0G5tVoJqehhwYxEdTCxgb9MEA
+      oLSod/kjcOiTyOZ0bK4toqg6sPzJJMKxEagAHC3qt1N38bNrkzjdOAc3qjBtHsxN/Rih8Qso
+      NzQ4bY771tcL63j3/au4+Oxl5AsVBIM25Kan4YsdQ6ZQRdAduO//Qb1SwuZ6Eut2D6LKDirw
+      4u6HVxEamUDDMOH5yl3hPq99oBGglc3kMoqqgonjRw5UpzeruD45jeHhBApVFW7U4B4YxXAs
+      1FZ9aXsdNbixurSERDyMiirBrOQROTKBaKj1UNms5JEtaVhfXUQ0HkexpsMr1+AMjmAkvnc/
+      ZbeZm59ADsSgFbcQGowhvV1B1CfDcIRwbLT1kaflO1Mo6C64jAqcvhC2c0UkBv2o6XZMHB9t
+      WV/IpLC0VUbIoUNyBZFNb2BkJIFcuYmzJ8Zb1lcKW5hZTiPsc0CTnajmt5AYHsFGtoQLT5xs
+      WQ8AyZVl2BwyChUdZq2A0GACyY1tXHzqLBT5/l+cAJBZT6Kp69gq1BCwN+HwR5FJp3Hu/HnL
+      CLKfeimHqbkVxCJBNE0F9UIW0cQQkpkCnn7y9L6h+3989ZBDIqJ9RAAAAABJRU5ErkJggg==
+    </thumbnail>
+    <thumbnail height='192' name='Time vs LabelIters' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7EAAAOxAGVKw4b
+      AAAgAElEQVR4nOy9d5RdV3mw/5x2+71zp97pRVPUm+UmW7bl3rAd40UJECCENAg15AtJvpTF
+      7wvh40sIJISQEJoTsDHFxjYuyAUXdVu9jKTpvd3e7z3n7N8fVxp7Rm00Go3G0nnW0lqambPP
+      u095z9773W+RhBACC4vLFPlid8DC4mKinvhPKpXiXAeDXC6HzWY763HxeByv13vuvQMMw0BR
+      lHlrdznJNE0TWT73b+A77TrP1HZSAVwu16xO7na7z3pMMBic0XGnIp/Po2navLW7XGQKITAM
+      A1VVz37wHMk8n7YXSuYMrl6QTmcw8hmEbENVVYRp4nI5Z9UZC4uFxFkVIJeK88Kr26kocpGI
+      jDMYznLzrXeckwLMduiysLjQnFUBbC4ffo8TSejIqp3KSj/j4xOUFznJZrMzWgPIskw+n59V
+      B03TnFXb2ba73GTOxgj4TrzO07Wd0QRww/XXn/Q7SZIwDGNG87JLac54qci01gAFZnT1kiTN
+      SrCFxUJnXvYBLAWyWKjMiwLY7fb5EGNhcc7MiwJks9n5EGNhcc7MiwJY7kYWCxXLF8jissZa
+      A1hc1syLAui6Ph9iLCzOmXlRAMMw5kOMhcU5Y60BLC5r5kUBZuIvZGFxMbDMoBaXNfOiALP1
+      4rOwuNDM2BXwtRd/RR4b4USW1WvW0dJQdSH7ZWExL8xQAUxkzY2cTaLIkMsbZDKZGccDSJJ0
+      yfiPX2oyrXiAGSGzZs0ahGJDURSEaeBwOGYcD6Bp2iXjP36pyLTiAQrM+OrdPv+shEMhe4SF
+      xULE2gewuKyZFwWwguItFirzogCznbtZWFxo5kUBMpnMfIixsDhnpimAzhtbXuPN/UcuTm8s
+      LOaZKQqQTiaZiMTmfFiwguItFipT3vVcNkk8lmR4ZHROhVgBMRYLlSn7AEUlFfjdGr6KwJwK
+      sfYBLBYq02Y7Jormosg9t4lvTdOc0/NZWMwVJ033JVkhGAxejL5YWMw701whNIqLndj8pXMq
+      xFoDWFxoUjmdV46OIyFxU1s5TtvMNl+njQA5wuEMoeD4nHbOCoq3uJCkcjpf23SUCq+dUo+N
+      r206Qjo/szj0aSOAQj6ToqS2ftphgt7Oo+QMkDQ7muagobZyxh20guItLiSbO4LcvjTAuoYS
+      ALK6yfauIBsXV5y17TQFkMgkwwSjyWmHCbo6u3C7new+1MlvvfeDZLNZcrncjKY3hmHMehQw
+      TXNWbWfb7nKSOdsP04K7TmGS1wvv2Hgix0gkTZlHmzz+TG2nKYBOTqioTLfaSDQ2NZLJm9x+
+      ZyuJ0CjlDXVomjYjRzeHwzFrhzghxKzazradJfM0xwKhRBZNkXFp8oK6zhvaKvjapqNsOjzG
+      kdE4R0cT3Ly4nKuaSnHZ1DO2naIAE6PjFPmL0GzTv+oSTa1LT2osSdKMd3nPZzd4tm0tmadH
+      CDHj52eYgm+93IGmyuR0k3KPxvuvbpjz/gohMI8HqCnyycecrp1DU7hvVTW/2D2Az6Hx6B9c
+      y4HBKP/8wjH+6p6lZ2w7RQGCwwMMTwSp8px97nQuWEHx72xebh9jbb2fDa3lCCH47utdDITT
+      1JWcvbJoNJ1nKJKmudyDTT29k40QgteOTbC1KwgC7l1VxfJq3xmVTAhBOm8gBMQyeRYHvNT4
+      nbQFvKiyxMNbeycV6nRMUQBPcSkeuw1Ftfz3Ld6iP5zirhUFo4ckSdT5nYxEM2dVgBcPj7Kn
+      P8Kicjc/2dnPx29oIuA5tWv8UDTDvoEIf3p7G4YQ/POmozSWufHYTx20KITgmf0jHB6OIUkQ
+      8DloH46Rzpvs6A7y6I5+bltagSxx0oT+7Uz1BUolyJoCTZ1b//3ZxJ1aXHyEEOQNk5vayvnJ
+      zn4SWZ1QMsf2njDLa3xnbJvTTXb2hPn87W08uLaWP7tzMT/Z2X/a44ciaRZX+lAVGZsiU1Xk
+      JJI6/cxhLJ6lJ5jk83e08bnb28jkDR5aV0trwMOL7WPctizAH9y4aMoIkskbPLqjj6+/cJRn
+      9w9jmOLkmGBZlhHMbSKr2VQjt5h7TCGIpPLYVRnXWTaKhBD85sg4O3tCGELQM5Hks4/uZjia
+      4SsPLsdlO/NHTTdN7MenPDndJJLKs28gyrdf7WZ9cxnrGoqnvJyLA17+9aUO2gIe0nmD5w+O
+      0DWR5NqmEm5f9pZv2oksFsmsTpFT48QZStw27KrCH93UfNrr+cnOfsKpHBOJLFs6gvSGUlMV
+      oGbREu6uaUbR5jaVoeUMd/HRDZPvbe5BN0ySOYOrGovZ0Fxy0nHhZI6n9w8zHEkTSeX50gPL
+      +fGOPkKJHL97fROKLPGzN/tZXluMfIb5uVNTsKkyT+8bZltXkB3dIRrL3Ny9PMDLR4PYVJlV
+      tW8lWvA5NT52fSPPHxpl06FRbIrMhpZSdvaE2T8Y5bO3NiOE4MhInKf2DWOYJvsGouzuC2MI
+      cKgyy6p9/OPzRxAIblsaYG19MamczuNvDjAaz/GbI+MEfA6+8dtryOuCu77xKsrf/d3f/d2J
+      Tigq7Nr+Bv1DQ5RWVGPXzvyVyOfzM8oLFI1GKSoqOutxp8I0zVmZzWbb7lKVubs/ghDwwWvr
+      uaaphJ++OcC6ej+2t633dvWG+dLTh0jnDGIZnVAyy47uMK91TBDL5PnV/mG2dEzQOZ7koStq
+      0JTCFz6bN3jl6Dh7B6IUu2yoioQqS6xrKOFbv+mk0ufA79L43O2tvHJ0grtWVLK1K8jquqmZ
+      RrwOjeXVPl5sH+N9V9Vx29IAiyu9fOvlDq5pKuGF9nG++VIHS6t8VPud/Gr/CCPRDE1lbsLJ
+      HPsGonx4fSO6YfLEniGWVvn4xa5B6oqdHBtPEs3kWVnr58hInFAqRzpvnOwMl89lkWRIJuYu
+      jNEKip97hBD0hVJ85/Uevv1KJ/2h1ElJroQQ6IZJ3jDpGEuABKYomBjtqoxuvHV8Kqfz5WcO
+      c+/KKr784EruWB7gwGCUcCpHmcfOrr4wpilYWVNE53iCzvHkpIzvbu5GkSXcNoWP/3Ann350
+      N/+86RhZ3aC+xMUf3bSIyiIHsbROIquzsztEU6mbnG6iG1OTc6myRI3fyVAkg24KdnaH0BSZ
+      f/z1MV49Ok5vKMX3Xu/ma5uOEk5m+ZNbWhmKpNk3GOXXh0b47e9sI5HVWVrl45e7Bwklc5R5
+      bCyv9nHb0gC7+8JsOjSKBCyr8k1fAwh0Q1BT3UhluXfOHpYVFD/3JLMGP9rWy4evrUNVVb73
+      ejefurV10mqSzhv8z9ZexuJZjozGub65lGf2B9nRHWRZlY8Slw23vfBhEkLwi12DBJM5ntk/
+      TCSd512rqlhS5ePAUIyhSBpNkekJJvE6VBYHvDx3YIQVNUXEszqGKbihtZyv/foIzeUeyn12
+      /C6Nj35/J05N4Y9/tItrmkr5308cQCAIeB0ossSL7WO4bAo3tJaxvrmM7V1BXmofI5nV+cWu
+      QZ49MIJumJR57ei6QXcwSTSVp6ncTV8whW4KvvlyBzZFIpzMYQpBwKfy3de7ubqphP2DMVbW
+      +NjdH2VXXwTdFIRTOSQkntw3xAOra6YqQCwSZqC7k7jkYvGiujl7WFZQ/NzTF0qxtNpHhdeO
+      pmksqfLRH0qxtKpgnXli9yBXNhbTOZ5kaZWXSCrPtz90BT/fNUhWN/nw+kaEWXCFmEjk+O9t
+      veQMkyOjcSYShYXiwaEY8YxOc7mbwUiGa5pKGIykSWV1Do/EODYap6HUTSKjk8zpjMazdE0k
+      cdoUnu4d5uhonKsai6nwOhgIp7hlSQXLq72MxnNMxLNk8gafu72N/3y1i61dIR57o58HVlcj
+      SRLdEwnWN5exsqaIn77ZTzpnUOyyUezW6B5PkjdNJGA4ksZtV8nqJoosMR7PYpqCFw6PUeax
+      ccuSCp7aO8SdK6p4au8Qf3vfcq5sLGZPX4Svv3Bs6hQoHo5S2bSI2qryeX+gFudGtd/B0ZE4
+      8YxOLJ3n2GicqqK3ApnG41mayz0MhlNoisybvWGSWYMNLWUossSJjVYhBE/tGyKnm3zm1laW
+      VvromUiyrz/KuvpiqoocmAJK3TZ29oToGI0T8Dn445uaeebACD0TSe5ZWcW/v9zJ0dE4vaEU
+      /eEUw9E0iyu9FLtt3L48gNuu0jmeQAJ+uWeQlgoPO3tC9AZT+Bwq//VaFw0lLv57Wy9P7R2i
+      xGNjV1+Yn+8aIJLKE8vk6QunSOUM8oaJEIU9CaemkMgW/HxUWUJTZHKGicumcGNbObcuDVBf
+      7OT65lJayj1c01RC51iSp/YNk8rp06xATQ1s27IHX9ncfrGtoPhTI4SgJ5hie3eQUCLLvauq
+      qS9xzeh+FTk13rWqmu9v6UWWZe5bXU2R863HWeN38tmf7GEgnMIwBU1lHj76g5147Sr3rHor
+      s/fmzgme2D3I0iofj73Rz61LAozEMuQMk8WVXgwhGIlmSGR1HKrC6lo/n7m1mU2HRomk8/xi
+      9yB/ftdiWgMe8qaJ26aSyhp8ZH0jP9jaQ7HLhixJHBiM8ulbW/n6pqMsrykip5vc2FbOrw+O
+      cHQ0TrHLxuHhGACJrI6mSMQzOsFElhq/k0QWwqk8Ekwa6U1TkDNMbIpMRhiYQiCEoKXCw1Ak
+      Q+dYgk8/spvxeBZlSw/tIzH+/pnD6IYgndMZCKenWoFAoePQTrSSehqqzz4KzNQKlM1mcbvd
+      Zz3uVFyKFhkovPz/+WoX//LSMVbVFrFvIErHWIJqv4sS98wybpd77VzVUMT1rRWUe+2TijMS
+      zfCt33RQ7LIhAJsq0zmeoLHUzTVNJYSTOZrLPcjAk3uHWV5dhG4IPnhNPT/e0UfHeLLwpRxP
+      EknlKPXYKXZpfOWhVcQyOgcHo/zFPUvRFJnt3UFqi12UemzsH4jy/qvr2N0f4dBwjOXVPsbi
+      Wd7sCfOP71nNipoi9vSF8To19vRHqC9x8XrHBJm8wWgsSzpvkNVNBJDNm8jHfZXyx023p0pk
+      bZgC3RS4j+9r6IZgLJ6dNMNWFjnZ2FbOsbEEr3VM0D4c58hYnN19EWRJmjoFCo31g6McIx0/
+      +eHm0/T39TE8Ns7I6MSMHvIJrH2Ak+kNpRiPZ3nvlXW876p6PnZdA+VeO5sOnXtGDiEEmbyB
+      YQrimTzf29xNc7mHW5dWcGw0QU43cdtVjo7GefXYBM/sH+aLv9hP+2gcj13lnpVVbDo0yl8+
+      vp+9/RHuWBbg//zWSjYuLkeVZYYiab7y0CpW1/nZ0FLKYCTNv7x4jL5gir951zK2dAZxaAoO
+      m4LHrvKHNzbTFvAyFElzz4pKvv2hdTSUupEkid+5th4h4PqWMg4Px7i6qYQil43xRJZs3pz0
+      3VEVCUWW0E1BMle4tjNxIgAmbwrqil08uLYGu6rwmVtbeXhbL5s7g1R47aTzBjZF5vqWMvTp
+      O8HFZQEUI41ic0y/xbQf2sfwcJCO/mEefN8HMU1zxvnlDcM4rzJJs227kGUmMnkCRQ5imTym
+      KShyagyG0ywqd5+T7Kxu8l+bO0nlCve4NeBlbZ2fwUiajrEEecPEFAJFlginclR47fhdNmLp
+      PI+9MUiFz87DW3v4we9exYvtYzy1d4i8YaIpEh9Z34DfqfHcwRECPjtCCJZV+Wir8PCJjc3Y
+      VZkX28dYWulFAj50TT0/e3OA0ViGxlIXf3pHKxVex5T70lLh4RMb3YxEM1QVOegYixNO5qgq
+      chQWsMc9QnVDIMuFeb1+mpd/ynRIQEY3j2+glfH+q+v40H/t4OsvHCWczJHIGuiGiabIky4W
+      FV77VAWQZJXlq1YwGjs5eKCkrIJoLMt1G25gYniQosZadF2fUVDFiVz0s8E0zVm1nW27+ZLZ
+      VuHh528OoJuCf//NMfYPRFAUhc/e2nJOsp89MMK6ej9X1Pv53uYe/vPVLlQZPnNrK1u7QlT7
+      nXz1oVUMhFP8ySN7yORN7lgeYNOhUfpCKT5zawufe2wvMgK7pnB1UzGHh+P0TiQo89h5vWOc
+      G1vLEKaJAfgcClc1FvP/nmtHlqC2xM2HrqnDMAwcqsSHrplqPZx+LaZp4tIUFpW52NoVpKXc
+      zZu9YYKJwstf4XUQSecKo4EpkE/hFn0CWZYmjzHMgpILBBld53+29mCYgl29YRJZHZdNRZak
+      wt6DabJvIEIqZ0xVgHgkimRzoWfHpomSqKxporKmacpvdV2fkaOb0+mctUOcEGJWbWfbbj5l
+      /vndS3ly7xDxjM7v39jMmvqSU/rBn4nxRJ5bl/noCqaxaSo3tZWztr6Y/+9Xh/E5NLK6SddE
+      kpxe8IlcUuVl4+IK+oIpgskcNcUubllSwV0rqmgsdfHykXG2dYX4ws/2oyky96+p5r1X1k3p
+      1w2tZWxcetw7lHMzcpy4R0IIVFnm317poms8SbnXwVA0zWgsgyQV1i2yJJHOG1O+9G+XdGJa
+      ZJgCCVAkCY9D5fmDYzSVuWkNeOgLpShx29FNE5Co8jsIJnLcsiTAju7QVAVQNRsul4sVK04O
+      fjkfLveg+Jxu8vS+IfpCKRaVebh7ZSWaIuPQFN57ZeGLmc/nz/nlB7i+pZQfb+/D51QZDKdY
+      UVOEKQRr6/08uLaGx3cP8vS+YYQo+NuossRXnj1MJJWfdEj76HVNfG9zN9F0Hoem8MOPXY1p
+      QrFbw6kpp3zBz+QHNBOGoxnGE1lW1/o5OhonmRM0lroZj2dJ5XRubCvHNAVv9oXxOTRM02Qo
+      mgEkHJqMpsjEMnlUWSJvCFRFotRj46a2clbWFrG2zk9LhZcvP3OY7V0T3LmilmAixytHx1nX
+      UMz+wSh/eNOiqQrgdDvYsWU75Q2NFPk853WBb+dyD4p/cs8gZV47d62o5LVjEzx3YIT7VlfP
+      ybmXVXqwqwrbukOMxbPcubySf33pGEVOjfWLSnFqCsFkjtuXBfjGC8foGEuwqtbP4eEYf3BD
+      YUR32hQ+eXPLnPRnpnSNJ0hkdHb2hFBlmVKPja8+tIpP/ngXhhD4nBp/fe9StnYF+cHmHvK6
+      gcOm0lzu5i/uXko0ned3vrsdn1PjoStqOTAYZUNrGQDXNZfxxO5BSj2FRe+G1nJsqsyxsQR/
+      de9Sbl8WoDeY5NcHR08Oik9ExhC+MpbN6+24tOkLp3nX6mocWmHb/zuvds/p+ZdU+VhS5ePa
+      phK+8eIx9vZH+Nv7lqHIEsdGEyyv8SFLEp+5tZVDwzHCqRyfva0V20X0Uq8rcbF3IMLGxRW8
+      eHiU7okk33mtm+oiJ9VFTtbW+XFoCtc1l7G3P0KxSyOYzNMW8FLitnF4JMaVjSUEfHb29Eeo
+      KnLw21fX828vdwBw5/IAX32uHY9D5TO3NGO3aQQTOW5bGkCWJJrKPHSMdU5XAIN0No9vjjeu
+      LvdK8TV+J2/0hLiysYStnUEay84eSjgbTihCOJXj+5t7eGrvMIvK3ayoLnjiyrLEiprC/8/H
+      MDEX+BwadcUuZAmq/U5GYoWIsNpiJ3/9rmVEUnm++PP9RNI5qoucVHht/Nmdi9nZHeLhrb2s
+      qPHxrQ9ewe6+CKYQXFFfjENT+PiGJn6xe5CJRI5rF5Vy/5pqosks3361h/2DUb709CE+eXMz
+      mZzB0dEEkphic8vwi0eepGnVWtYubz3rRSSTyRltcA0PD1NVNbu6wgutquBs2mXzBr/cO8RA
+      OE1jqYv7VlWjTYuPnWuZumlimAKbIp9yDn+xq0QKIfj5rgH6Q2myusH1LWUsqfRR5NSwqTKZ
+      vMHXNh3lT+9oQ5ElthwbJ541ufdtu9jBRJYn9w5hmoJ7V1VTWTTdfF/gO68c45ZlVXjsKl9/
+      4Sh9wTTXLiqhptg5dQQYHwtSVROYc9eFyz0o3v62xe58ocoyZ4hBv+hIksRDV9QSz+ioinRS
+      hNlINIOmSPzrix2YQlDrtzMWzwMFBUhkdP7t5Q5+b8MiFBn+6/UuPrmxheJT7KInsgYVXjte
+      h8Zfv2sZ//FKF5+6tZX0dDNof2c3mseL23lqTbI4NyKpHI/u7CeR0VlS6eXulVWzsvRcqkiS
+      hM/51khyYDDKpkOjyLLEPSsqeeXoBH9252LaAh5+uKWH+pK3Zhs7eoLcsbySmuKCA+CDa2t4
+      5eg4v7W25iQ51zWX8sMtPdzUVsHmzgmuWVSIhHPalKkKUFnXRKC6Com5fUiXY1C8KQQPb+3l
+      vtXV1PidPL1viK1dQTa0lF3srl1QTCE4OBijO5hkVW0RDTN07usLpXjh8CgPrKlmW1eIv/7l
+      AUxT8JOdfYzFs9gVadLVG6DYZaM/nJ78eSyWpfQ0PlRX1Psp8zk5NBTjliUVtFa8ZeGc8mZW
+      156sPXPB5RgRphsFT8XG0sILcO2iUn59aPSSVICRaIZn9g/jtCk4NYV4Js/a+mJ+sWuAe1ZW
+      saRyagYJU4iTNtBeOTLG+kWlfPf1HszjHqh5Q/CR6xqpK3bxJz/eNSWGeFWtn62dQb6/uRtF
+      kggmc3zqlpbJ8w9F0pR57DiOh/U2l3toLj/ZtD8vn+ZsNjsfYhYUmiLhtavs7AmjyBKvd0xw
+      wyX48o/Hs3zntS4+fkMT4/Esf/X4AR77o/U4NYVqv4Of7ByYVIBYOs9/b+0mlTepLXbxnnW1
+      KLJEfzhNfyjN47sHGYxkWFnjI3M8XPLzP9lLudeOYZo43xajrsgSf7yxmaFIBkMIavxOHt89
+      QG8wRVY3qfQ56A0m+ZNbWvA7Tv8BXsDLpHc2kiTxvqvq+NbLHTy+awDDMGkfiU1xdNMNk87x
+      BEOR9BnONP/kdINYOj8jp7xnDwzzkesaebMnzBO7hxiPZ/m3lzqIpHIMhNOTrt1CCH60vY/b
+      lwb43O1tBLx2nto3zFefP8IXHtvLMweGOTQcI2+Y7OmPsK6+GJdNRVUkUjmDB1ZX8dXn2wkn
+      3/IsliSJmmIn9SUuXjg8SrHLxvuurGNnd4gPXdvAh65t4MX26W49U5mXEeByzQvUPhLnA9fU
+      T+a1+caLx0hkdbwOjZxu8u+/6aTcayeWyVPhsfHgFbUAk45dc2mNE0Kc9bxCCJ7cO0T7SBy3
+      XSWeyfOx65sI+E5vFPE5NA4MRukJpnDaFG5qK+eFw6O83jGBKktc3VTCju4Q6xqKiWXy1JU4
+      UWWZKxqK+cSPdlHmsXP78gDtwzGePTBCLJ0/fu9iXNNUwuHhGNV+JxOJHD6Hxt8+eZC/edcy
+      yrxT89eGkjnW1vmp9DuQj4+4u3rDPHiKRfHbmbECjA/3I9k9aJoNYej4/TNPc3K5boTZFJns
+      cSc0QeHFPuFDs7c/QmvAw90rKhHAPz3fzkgsyy92DZDKGZS6bXzw2gbsqkw6b7C9K0jOMLm6
+      sQRTFF7W6SY/wxQksjoeuzrF2pTM6vzPtl5iGR2fQ6Wh1EVPMMWKai/XtZRP9mlnTxjdEPz5
+      XUuAwpTlX1/q4C/vWXJapbl7ZSVf/Pl+TCFIZHSubiphZW0RT+4d4sPrG2ip8PCjbX1s6Zzg
+      yEicL/xsP5+5rY1tXUGq/U7W1PnpD6XY0hnEY1eJmHlyukk0neflI+O0BjxkdJM/umkRD2/r
+      556VVTy9b5iPXt84pR/3r67mW7/pJKsbfOz6JkxT8J4ra2kodZ/RDD9DBRDYHC4O7tnB4d5R
+      7rn/IfxnbzTJpR4UL4Tg8d2DHByMIssS1ywq5dYlFayqLWJrV5Dvb+khkSmk6jiRkc1E8HaL
+      qAQ8sqOP+1dX01zuZnt3iKf3DnHH8gCff2wvDSUuXHaFv//VYe5YFqDUU/gCfujqWjQNRmMZ
+      frC5B49DJZHR+eQtLZMZIn725gCNZW5q/E5ePDzGY28M8LnbWtndF8IwJa5vLeW1oxP8YEsP
+      D6ypJns8Quvx3YMcHIry+O5B8oZJkdPGxsXlnJhRG6bgmX3DSMDWziBLKr2oisx/vd7NaDTD
+      V587giJLLK/2sXcgwqO/fy2/2jfI3z55kE/f0srGxRX8aHsvkgTxTCEMEgEranwkMgbFLo2x
+      WAaPXeVfX+rkhrZyit3aKTMXuu0qX7ijDcG5eahOC4k83ROG3dtfp6i8Gk9RMflcHr/PTSaT
+      QVXVyeCY0/2LRqN4PJ6zHne6f0KIeW13rm1394WZSGT52HV13NBaxqZDo1R4NLx2hbV1fgJe
+      G6tri1hR7Z1sU+zSeGrvMAOhBFs6JqgsshNM5rhtSTkSAq9dYXNHkExO58BgjC//1nJyusGh
+      4Thr64r43fX1mKZgb1+Ilgo3P9rex2+tqWZjWxmhRJaXDo/SXObCpsAPt/YiBISTWf7rtS5q
+      /E7imTyLAx729EfoHk9g1xQ0RcLv1PjNkTF2dAf58Pp6eiaSPLF7iDuXVeDQZH61b4gr6nwI
+      Ifjxjl62d4XoDiZ5YE0Nzx0YYVdfGImC28W9KyuJZ3T6QykqvHacmsyNraUMRTM8tLYar12h
+      uczNls4Q1ywqIZTMEU7n0A3BF+9q45VjE/zBDU3ct7qavf0RNndM8Oz+EWr9DlbXeBGnem7n
+      +DxnNgJIEus33nHSrw3DmNGWuKqqC8Yt4UK0PTKWLGRbUBQ0TWNtfTHdwQyN5QXrR33Z1HP1
+      BpM89sYAAugOZfjANfVU+2z8av8oLx+d4JpFpTxzYJR1jSVIFJK6CkmmL5zB41Bx2zU0TWNp
+      dRE7e4JomkbWEJR5nWztCjOWyON12vju5l4+dUsriZxBld+BKst4nRoraor4yHWN/NlP97Ch
+      pZyxRI4PXNvI6rpivre5GwnwuWx0jKfoDaW5Z1UVkiyzobWcPQNRUrqgxKHRHUxjCHj3FbXc
+      2FbOIzv6WFzpxefQGIyk6Q2lMcyCybInmOTJfSPsG4hy35qayftbW6pRWeTgw9c18sFrGniz
+      N8w/v3CU/3yth3tXVfPA2lpkSeKZ/cN87vbFNFd4eHb/MIdGkqytLz7v5zkvq9NLvUrkVY0l
+      k7G8phBs7gxOOp1NRzdNHt3Rzx/cuIgv3r2EJZVexmJZJGB1nZ9f7B7kU4/sJglSZOMAACAA
+      SURBVJjIsb65lCsbS1hW7eOTP97FpkOjJDI696yqQgjBm71hFgcKCcw2tJTxvc3dPLN/mHAq
+      x72rqihx2wilcrQFvJR57BwbS+C1axwdjfO/nzhAwOfk/jXVkxOKyiIHH72usbAje7CQ2vxj
+      1zexuWOCpVU+0nmDREafNEfaVRlZKoRlIgpBLNc0lXBkNE4qq6NIEooMDaUuNFnmf925mE/d
+      0jLFng+woqaI5w+M4HWo+Bwqv3/DIp761AY+f3sbDk0hqxv4nRqraovw2FUaywpxA3PBzKZA
+      p2GmWSHC4TA+35nTaZ+Od0JWiBK3jUTW4Mc7+ni9I8idywMsKnefch6ayRvsHYhwU1s5kiQh
+      BHQHkzSXufjO6z381b1Lee+VdRwcilLislHutbOhpYyrmkq4eUkFpW47Lx8ZZ3tXCJC4e3kA
+      VVWoKnJQVeRgNJ5FlWWqixzs6Y9w5/JKcrrJgaEYVUUOMnmTyiIHSyt9/MENjXgcGsORDJ3j
+      SYqcGu0jcfxujS/evYSuiSQD4TStFR52dofZ1h3i/tU1lHsKpbEWlXvY0hnkqb1DPL1viNW1
+      fnb0hPDYNUAimdMLOYU8dv7i7qU0lrmROblcUX2Ji7F4lk0HR7FrCvevrpmyiLcpMvsGo4RT
+      OumcMRlPcbYM1TN5ntO8Qc+NmXqD9vX1UV8/vfLkzHgnTIHOpZ0Qgu+81sWyKh8NpW4ee6Of
+      96yrw22TePSNQT6xsRlJktjRHSKWznPb21KDn2ifyZsIBE5NQdf1KTJNIdjaGWQgnOLWpQHK
+      PIVg9vFElnhap77EhabKU7xBDVOwozvE4eEYjWVuNrSUTanmIkRhV1uRJFRFnnKdumESTObo
+      D6WIpPNc2VCw32uKdDy43cSmvuWROtt7m8rk2NlbyFV6XXPplDQwZ+NMMi0FuAgys3mDF9vH
+      mEhk2dBSRlOZm7yu840XO7l/TTWlHjvffb2bj6xvPK2L7/n29WK7Qy8UmfOyEXaprwHOFbum
+      cM/KqfEREvCHNzXz5N4hEhmdh66oJeCz7tuFZl4U4HKPCZ4pPqfGh65tmEx0ZXHhmRcFuNyz
+      QpwLhin4j1c6J9OB1Ja4WFlTxJJKr5Vj9QJw+TnqL3AOD8cI+Bw4NIV/ePYw1zSVMhzJoMgS
+      bYG5q9lwscgbgl39b5VIutgBQvOyD7AQCmQIIUgeL+Zw4udEVj+v9IkXgjKPnc7xBI/s7COn
+      mxwcirK6zs/+wejF7tp5Y5qC/3yti4lkjs7xJD/e0XfR7/9lMwK8eHiMbd1B+kOpghut34nb
+      rlLs0vjodY1zPr3oCSZ5Yvfg8djXGmqLZ5YJorLIwd0rq3jt2AQOTSFnmPx4ey//9N7Vc9q/
+      i0E4lUNVFO45XnP4q88fIWeY2C9iXep5GQEuRFC8bppsOjTCzu7Q5O+EEPxyzyD/97l2hiJv
+      OeClcwaP7OxjT1+EXx8c5chInEd29BFMZPnlniG6jte7OhOmEBwcivLU3iF6g8kzfrlyuskj
+      2/v4nWsb+MDV9fzPtl7yxpnKNU9lZU0Rn7m1lVuWVLC2rpgvPbACr+Pij6Lni8euEk7mCCVz
+      DEUzSBSC9y8m7whHfcMUbOsqbO6c4Nu/6cSpKfSFUzy5dwiAnmCK0PHQuIe39QKFEjpfea6d
+      nokkfaFUwf9mIoluCDYdGmVZtY9Hd/adUb4Qgsd29nNwsLBR9PzBUV49Oo4Qgq2dE7zvP7by
+      hZ/unaxUkskbOG0KJW4bZR5boWqJPnMFALh1aQV/cnMLX3pg+Vn3At4p2DWFD1xdy4+29/HL
+      PYP83oamy2MNcKrNFiEEOd3k+5u7+T9PH+I3R04fufPw1h7CyRz/vbWX4WgheiqSynN9Sxnv
+      WllF+/HKIkVOjYFwmteOTVB23Fd+70CEe1ZW8omNLUgSlHpsqLKEy64Uak65tLMWpAin8gST
+      Od5zZS0ra4r4vQ1N7OgJk8wZfPX5I3z9/WtYVuXjkR0FRfI4VLwOlZ+9OcBP3uin3Gs/a2Hq
+      6UiSRJnXjtt+ac1S60tcfPrWVj6xsWXSpftiMuN4gF07tpLJ5tBlO9W1jbQ0zCzRVTyT52uv
+      DhMojvGZW9smt9gHwmn+/pnDVPoc/PW7lvG1TUdY11B8yqF+NJbhPVfWEc3kCSVzVBU5WV3n
+      5+svHCOVM7hvdaEvJW4bH7+hiZ6JFL97PGDiprYKvvnyMbJ5k/tXV/Pozn6q/U7+6t6llLhs
+      5E2TqxpPLhj9djJ5Y7ICCYAsFfLWIwR2VaZ7PMlAOEVzmfP43yU+sr6Rw8MxJKmQzcAyYS5M
+      Zv55Ue3okXF6J9LUNbWRyWRIJBKEw2FsNhvZbHZyXuxwOMjlcpimyeu9KY70DnFg0MW6gEpL
+      iQ1N09jZHUE2dY4NBRkYHCKZStPf34/HriLLMjabjUwmg2EY3N6g8X+f3EWFU8JTIejri3J1
+      pZ1mtw0ZgcuMMTKSQQhBPp+nRoOJ8TSqqpLL5XjfUtekq/K9i2y4bQpOu47NJpPNZhkeHJjs
+      dz6fJ5fLoSgKdrsdwzDI5vL0jATZeRiqiuwcHI6jp+NEg2P86Q2VfPuFvTSWOLi20s3Y2Njk
+      vfBLEnabneGhQUyzMAWy2+1T6irYbLbCxlcmg6IoqGrh+k9U1TnR7xNBRZIkYbfbJ2UYhoHb
+      XYh6evs5TdNE1/XJazrV3wzDwOFwIEnSpDxVVVEUZTKRwYlncUKeJEkF/yHDOOs1nVj7vf2a
+      DMPAZrOd8Zre/ixOnFNRClmqT+wpaZo2pd8n7t2p+q3rOoqiTHkvT/R7xr5A48P9GLIdze5E
+      6DnKykpn5AsUSeX485/spK68mC/cuXgyTUXeMNnWFaR9OM5oPMMtiyu47hRZExaK70gklZus
+      pdtQ6uKBNdUnWS/eST4yli9QgXlxhhsYGKC2tnZWMhbaDbtUZFoKUGBeFsGXa1C8xcJnXhTg
+      ckyMZfHOYHL8S6VS57wtPdNsD5lMhmTy7JtNp8IwjFmVWZ1tu8tN5myi5t6J13m6tpMK4HLN
+      rmjDTNYAPp9v1oWyF9qc8VKRaa0BClhTIIvLmsvGG9TC4lS8I3yBLCwuFO9Yb1ALi7ng0vK0
+      spgzDFPw7IFh2kfieO0q77+6niLnpTeVvWjeoBYLm61dQXK6yaduaeH2ZQF+uKVQueVSY14U
+      4HIskfROp2M0zvpFpdhVhaYyNzndRDcsBZgVlhn0nceqWj/PHRwhlsmzuz+C11HI9napYc1N
+      LE7J2no/mbzBD7f0UO618+H1cx83fT7ohslILIMsSQR8jllHllklkixOiSRJXNdSdkoX9YtN
+      PJPne69343fZMExBVjf46PVNU4rozZR5UQDLG9RirhBC8PNdg9y7qoqWikKepDd7wzy3f3iy
+      xtq5YK0BLC464nhd4J++0c9zB0ZI586cFnIinqWh9C3fsiWV3ilFs8+FeVGAi538yGJhE0nl
+      +d7mblbV+vE5VL7zWtcZ3xmfU2Ms9tZHtT+Uotw7uwD7GQfFjw8PIDu8yIqCMAxKis+lTJ6F
+      xenZ0x9h4+JyFld6EcLDrr4IsYx+yo03SZJ4cG0N39/czZJKH7pp0j2R5PdvWDQr2TMeAYQw
+      2ffGVn7+s5+T49zm9A7HpZHXxuLCUFXkoGMsgSkEWd0klsmfcUFb7rXzmdtaaSpzs6TSx6dv
+      bcU3y13qGcYEC7qPtTM6NgZ2H06Xh8WL6kilUni9Z0/YOjQ0RHV19aw6aJrmrKxIs21nyZx/
+      mQJ4ev8Ix0bimMA9KypZVuU9a7u56K9VIeYylbnQAmKml2GaD5lgbYRZLBAkSbooSXKtMqkW
+      lzXzogBWiSSLhcq8KIBVIslioWI56Vhc1kxTAEFv51G6+obnVIgVFG8xFwghiGXy51xr4UxM
+      sQKZZpYD+w9R3tDKovqZpT+3sJgPxuJZHt7egdeuksgarKot4u4Vleftoj1FASaGBzBlG6lZ
+      ZnE7HVZQvMVsGI1l+NH2XnK6SV8oxVceWoXveP2IR3f0sac/wtr64vOSMWUKVFGzCCUfwVQs
+      92WLi4tumPzHq118fMMiPnpdE+Fkjr39kcm/37m8km1doTOcYWZMWwPkyBt2Sv1zW4/Wigm2
+      OFcGI2may9z4nBpuu8LSyoKT3AmSOR2ndv42nGlnUCmvKEaf4ymLlRXC4lwp89gZjKQRQuB1
+      aGiaikSh1nA8k+eHW3q5Z+X5r1OnvZkSDqcTu2Nud26tgBiLc8VtV7mhtZx/eLYdp6bgUCSq
+      /U6++vwRHJrMxzY0UuE7fy/jaQpgkNMlcuEQ0HTeJ7ewOB/WN5dyZWMxecNEk8QFMadPmwJp
+      xEND2Dy+uRViBcVbzBJNkXHZLtwUetqZ88QjaZyZ2cVXng4rKN5ioXLSp9kQeRKx1KmOnTXW
+      GsBioTJlBIjHEpRXV+MtPb/NhelYQfEWC5UpI0DXwd3s3LWHjt7Bi9UfC4t5ZcoIUL1oMeti
+      Op7KufUDsoLiLRYqUxQgPNzPUDDM4qrGaYcJOtsPMjQ8TDQLS5auoKVh5koy2+p+FhYXmikK
+      UFZdT104iWlMczcVoKoKNbW1jOw/giEKpU+z2eyMLDy5XG7WDnGmac6q7WzbXW4yZ7M+eyde
+      5+naTlEAXTfw+UvxFp+8D6DaHGiai7vuvBNh6DgcDgzDmNHmhKqq75hsCZeLzIWWFeJiyZxy
+      9RXVVXQc6yYai1MRqHgr2ZAkUVM/+51hKyjeYqFy0j6Ans+hqDLpxMyqwM8EKyjeYqFyUkhk
+      XjeoqKonUD53LtFWULzFQmWKAqRTaXLpFKPj4YvVHwuLGSGEIJjIsn8gQiiZm/Vm65Q1QCw0
+      Sixt4DDm9ottBcVbzCVCCF5qH+PgUIxFZW5eOjLOqpoiNi4uP+cY4amL4Jp6HMpu1Dl+YRdS
+      bSmLhY8pBMdGE+R0g6VVvpNyhYZTeQ4OxfjkzS0osoRhCr75Ugdr6vwUu89ulhdCYJiFEWOK
+      AkiSQtvSxeRU1xxejrURZjFzDFPwby93UFnkwKHKPLl3mC/c2TZlrj4YSdNU5p4sjKfIEg2l
+      LoajmbMqgCkEzx8cYf9AFDjJHVowNjZBRePcOsNZWMyU9pEYtcVO3n283lddiYtNh0a5c2n5
+      5DE1ficvtY9hmOL4CGDSE0yycXH56U47ye6+MImMzhfuWAycQgFGBkZQvCXQ0jBnF2UFxVvM
+      lFTOwGN/67X0OFRS2alm9GKXxuraIr75UgcNpS56gkmuqC8+ZUWZE5imwBCCvf1R7llZiXx8
+      9JimACqqnCKSsoLi54uBcIofbe8jrxusayzhruXnn+zpncyq2iK+8mw7DaUuHJrCj7f38elb
+      WqccI0kSN7WVs7rWz3A0w8bF5RQ5tdPet4Fwmp/tHkYgGAilWVbtI3A8nnjam6njLq6hobZy
+      Ti/KCog5NXnd5Luvd/O/7lqCislT+0fZ0hnk+gVYm/dCY5iC1zsm6A0muWdlFXsHouR0k0/d
+      0kqx23aSL48kSRS7bWed8xum4NGdA/zxzS0UOTV+sWuQh7f20DGWQJZOkRXCbtMwxdzlXrQ4
+      PX2hFEsqfTg1hXze5PZlAX6wpeeyUwAhBE/sHsSuydyypIKn9w1z7aJS1tSdfyHGrG5g15TJ
+      EWJ5jQ9DCK5uKkGIk3aCJYr8PkZGRs9b8NuxguJPTaDIQW8wiXncJHd4OEZj6dlLTr0TMEzB
+      4eEYh4aikybH0yEEdE0kuHtFFbXFLt53ZR1bO4Nz0g+npuBUJbZ0BhmKpHl2/whXNZbQWOqm
+      qcx9comkwd4uPPXL5kT4Cayg+FPjeVvuG1UWFLnsfHzDOz8djW6YfOPFYzSWupEk+NX+ET57
+      WyvaKWp/AUgS2FWFsViGyiIH7SNxqormJohKkiQ+vL6Bl48FOXowzrtWVdFY+paZ/6S8QDan
+      n6rykjkRfgJrDXB61jeXcnVTCbl8Hoft9Au5dxI7ekKsrvNz29IAAL85MsbWziA3thXMlJFU
+      jsFwmvpSFx67iiRJfPCaen64tRdTCPxOjQ+vb5yz/thUmXetOnWV0ikK0HVskMUrl5NJz21a
+      FCso/swosoQqS5fEyw8FU6b3baZMr0NlPF7YDD0yEueZg2MsqfTy5N4hfvvqehrL3JR67Hz2
+      tlZ0Q6Ap83cvpoxJuVSU9vZ2QvG5TYticXmxflEpzx0coXMsQdd4gqf3DXN9SykAzx8a5Q9v
+      aub+NTV8/IYmnj0wMtlOliRsqowkSZPFMNI544J+QKeMAEtWX8GS1XMvxAqKv7xw21U+f3sb
+      T+8bRgj43G1teI/n9Zd4a0ZwuvfaNAUPb+slms6TzRusayjmxpa5nZaf4KTMcM8/+WsCzS2s
+      Wb54zoRYBTIuP7wOjd+++uTi6Hcur+Q/Xu2iLeClfTjGB645+Zj2kTgOVeYjt7RgCvjnF46y
+      rq4I/wXwKp6mADL5TJiJ6MlToMhIN8GMimHo2O3Oc9ossyLCLE7QFvDwR6UehiJpbl8awG0/
+      2U0mnslT6ilYDmUJXDaF3PREDXPESVagRCqH9xTmKklPMzKW5eC+XTzwng+SyWTI5XIzivc1
+      DGPWUWGmac6q7WzbXU4yZ/thOt/rdGsKreWuU/Yhbwg0WeKJ3YPIkkQsnUcWAp9dviD3dpoC
+      mBSXVhEoO9kb1F0coMpIU33n3SRDY1Q01qHr+owc3ZxO56wd4oQQs2o723aWzIsnM5LK893X
+      u1hU7uHmJRU89kY/77+qnvtWVyNM44LInKIAQwMj+PxustmT/fdVdymLpm1SStLMzFWmaZ6X
+      WWu2bS2Zp0cIMePnN1cyz9b2yb1DPHhFLc3lHgDW1hXzescEqiKTN40LInPKXGe4rx/N5cbp
+      nNs0JlZQvMVMCCZz1Pidkz/XFDsJJU8dTCWEoD+U4qm9QwyEU7M2lU5RgLrmNtatW0dbU92s
+      TmZhcT5U+Rx0jScmf+4cT1B5mjJIR0cTPPZGP3UlTh7Z0U/H29qdC1NjggOBWZ3kbFhB8RYz
+      4b411Xz/9W7e6C1kJYmm8vzuaXyjdnQHefcVtTSVufHaNbZ1B2mtOPdUPvMSqXKpbPFbXFg8
+      dpU/vrmZ4UghKVuV34F6Gk/i1oCXrZ1Bil0aW7uCLA7MLo/VvCiAFRS/8MnqBj0TKWqLnbjt
+      Fy+CT5Vl6krOnpTh6qYSMnmD/97ay+o6P+tmGcduxSpa0DmW4Ec7+lhW5ePx3QPctjTAlY1v
+      uR5k8gb/+WoXiWzBmPHbV9bQVHFxp7WyJLFxcQUbF1ec13nmRQGsoPiFzU/f7OfP71qMXVUw
+      TME/PHt4igI8vLWH+1dX01jmJp0z+Kdft/MX9yybTEvyTmZeQrWsoPiFjSnAdnz3X5YKX9e3
+      E0rmqD8eROK0KbjtGjn90gibnRcFsAJiFjYrqot4cu8Q8Uye145NUD0tGquqyEn7cAyAWDpP
+      KpvHrl0aYa7Wp9mC+1ZXsbkjyA+29NAW8PI706KxPnBNPT/c0sMTe4bQFJnfu77xpFHifBFC
+      kNNNNFWe83OfiXlRACsofmEjSRIbWsvY0HrqbBSaIvPxGxZN/jzX7u3pvMEPt/SQzOrIksRH
+      rmukZAY5PueCeVEAKyj+4mOYgmRWx2NXJ7OiLRSe3jvEVY0lXFHvpz+c5pEdfXzy5pZ5kT0v
+      CmCtAS4uY/EMP9jcg8umksrpfGxDE6Xz9IWdCWPxLHccz4hX6XOQys1f/Mi8KIAVFH9xeXzX
+      IO+/up76kkIezSd2D/J7Cyj9yjVNJfxkZz93r6hkR3eIpZVzV53obFiT88uAdN6Y/OKXuW0k
+      swsrQm9dQzFr6/188+UOPA6Vu1eeX6H2EwvqREY/68d3XkYAKyj+4nJdc9lkysXXjo2fdrF7
+      segYS/DM/mGubyljb38Ej12dUXpIwxR0jSdI5gzKPXaq/YX37LkDIxwYimJXFYQQfODqWspn
+      Uib1QnE5B8UbpkA3TWyKfEqnwERWRzdM3NrpF6a6YdIfTuOxq5R5bGR0EwQ4NBndFGCYJ+UV
+      EkIQSuYYjWXoGk8wGE7z2rFx7l1ZRVOZ+6TzZ3QTh1YwQXaOJRiJZVhW5aPEbTsnZ0bDFIzH
+      s+wfjFJf4qIt4DlleyEEqZyBKQT//kondcUuOscS3L+mmkd29LO23k9/KM2rR8cxhaC5zMXR
+      8SQNJW7WNRQjS/Df23rZ2hVkWZWPPf0Rllb5aK3w0BtM8dnbWvG7bAxF0vzkjUE+cXMLI9EM
+      /7Otl7xh4rKp/P4Ni5DEeUzQk8kkbvfZc1n29fVRX39y9P+JG3Gi0MGpbtTpihwLIRiOZnBo
+      yilNZtPbCSEwRCHlxgkxg+E0tSXOkzwOTyUzms7z+K4BxhM5msrc3L+6GpsqI4TAFIItHUFe
+      OTqGLMncu6qKtoCXl9pHeWb/COOJLLV+JzXFTlbX+rm6qYSn9w2zbyDCoeEYlUUOlga8fPKW
+      Vnb2hOgLpbi+pYwav5PuiSQ/e3OAA4NRUjmDpVXeyZcyb5johsFINEeJW8Pr0DgyGkc3TFoD
+      Xl47Os5AJE02byJLhQxpVzWVMBzJUF/q4t1rqmkJeHl0Zz9bO4MIBIok0TmeJG+Y+Jwa1zWX
+      Ih2//mK3jbpiF60VbjYdHsOmyDg0hcMjMUpcNoqcGr3BFAeGomR1E7sqc1VjCcXuwt/8To14
+      JkeFz0kklaNzPMm+gQgTiRwum0LeMDHNQqIwn1MlmMihKjI53eBEelEJUJVC/qB0zsBpU6gv
+      cdEXTJE8vnhW5ULm6LaAh6oiJ7v7wrRUeNjdF2FRuZucbnJkNIHbpsxcAbqPHSJvKtjdHhRJ
+      pbYmMCMFME3Bk290UFtRyrqG4smX3DAFBwaj/PrQCLohaAt4eWhd7Slf5EjG5OGtPTSVuXlw
+      bQ2SJPHTN/oJJnMkMjo3LS7nqsYShBD8av8w7SNx3ntFNfVlXkxT8D/be+kNpnjl6DjhZA67
+      KuO0KYRTeVbX+vnSA8uneCBOVwDDFHz9haO8+4oaaotd7BuIsG8gykeva+TlI+P8v+fbyRuC
+      R37vKkq9Tv5p01FSOZ324TjFLo14Vqct4KU3mOTulVVsOjjKu6+o4T9e7WJJZeGFPjISI5k1
+      aAl46R5PMBBOY9dkJhI5bIrM39y3DE2R+fIzh/nygytpKnPz108coK7ESX2pmx3dQdI5A4em
+      sqVzYtLkGUnnCXjtyLLESDSDbgpK3TbSeYMSt43VtX7KvDZeOzZBOJlDHL/exZVejozESWUN
+      jmfxodRtJ5TMIUnwV/cu5dcHR+kPp4hndJrL3RwcipE3TBxawacoq5tIEiwq89AXSuK2qaTz
+      Bg5NwW1XiKTyrKsvhD3OlZlEAgQFJTCFwKEpZPIFRUnlDBCFvxe7NMKp/EwXwSahWIqRnnae
+      e/Y5bF4/+XyebDZLOBwmHo8TDocJhUKTP0ciEUKhEJv29/PNF47ylz/fw57uEUKhENFolJcP
+      9PFPzx2kcyTCH66v4thQkN7hcUKhEJFIZPKckUiEf3+pnfevKWciHOWNjmFCoRCHh6O8f3Up
+      v3NFGU+92U0sFuNA7yg9oxHeu7KY777WQSwW45nd3XgVnV29QWLpPOFUjtF4ls7xJEvKHQyG
+      EvzL8wcIhUKT/T7R91gsRjQa5djAGHbylGgG6WSCJi8MBWMMjIX4xgtHubWliBub/XzvlSMk
+      kwlWB+xEEyk02eTdq8pRMLijzc9INEVzkQLCJBpPcNdiPw+uKKXSrVDlkhgKJ7ittYiNLX7s
+      CgyGU5S7NVw2mdFQjPaBCZpLHWzvGKV7aJzV1S5ePzLKzYu8pNJZHlxZxkAwTn2xA69DZV19
+      EVCoshJN5zGEwGWTKXaqtJW7iKdzpDJZftM+xrKAG5sq41BlvDaZTE4n4FFxaDKaAl67yvIq
+      D4oMDlWiayyGRzWJpfNUeFRWVnnI6YXYb5siTaYzkYAVlU7sqkwiq3NFjYc6v53GYjvpvMFQ
+      NM1cbktoioREIR2jKSCvG6gy3LSoCIeqYFNlFKng4QoztgJJ+Fx2Sqqb2HjLbUTGhpAkCVmW
+      0TQNRVFQVRVN01BVdcrP1cUuTEXDaVMp9Tgnj6n0u9BUhf+/vXNrjqO44vhvrjszO5fd1epu
+      C9kYG2xsoIITqFBUCBWKVEEqecpT8pXyEag8UaRSISQkDwkVF6SggJibA/gSQLYl67JarbQ7
+      s3Of6Tys5QBGWlvEsgH9n/v06dM7Z/v8u0+fRpKJC+inJbZZua4PVVUZd01OX+5ypZsw4gz6
+      GHcNXjnX5g/vL/Pw7AiqqlKvGqz4Ke/O+zSqFVRVZbpe5UKrj13R2IgyyqthEMDHSz73TbmD
+      sXzOjs/boqoqVUMnLbg2LkVVAQmzouEYKmEmeGtunelGFUVR+Gg5QJJkpmoWL32wRDtIee6N
+      S0x5Jot+SpgWqKrCqfNrvHlxg32NKvMbCZauoakK7SDDNTXCpKAX5yx3Yxa7Cf9p9VnuJRyZ
+      dLl73OXDRR/P0nn53yt044JTF9qYuspyN0ZXZM4t+0jA3Gr/akU2SPOSvBS0/ATX1CgBQ1Po
+      hBllKUiygigrEQLyAvJSkBWCOC9Y2IjRVZm0GKwGDbsy6EPAmStdJGmQVJcWAkWWSbICS1e4
+      1ImIs0G8H2Yl3Thnum6hSBKXOyH/z7S6ohQIYCPKkCWoaAog8cGVHnlZkuYlhRDUrEHYvCsc
+      4Oynl5jZN/2FixZCDJbIVy+scnapx9P3T3DvhHudbJZlyIrKm5+tsb9uXctKLErBvy52cAyV
+      Y1PetfZX1iM+awc8PONhVgZGXljx6fRTenHG6bl1wjTn+D6P/Q2LvBA8cnAEXZW/oPPL/OH5
+      ty+jqzJHJz1e/7TNoVGbHx0ZZbkX89zrFylKQVmWKIrM9w80+N5MnZfPLLGwHnJxbVBobNSp
+      cGzS5fHDo7z43hXemusw3wkZdw1+/ch+rIrGb9+4yFo/paqrPPvgFE1b8hy5aAAABl5JREFU
+      Z6Zh8fKZJdaCFBDcNVJFlSXirGDMqXCpE9JPCtbDlFYvYWEjJM5KJAaPzAkE55d90ry8Fksf
+      aFb51SMzHJ+u8ZtXLvDBwgZFKYizchCDGypJXhJnBZoyINtlOQgpTF3h8LhNnJXULI33Lm8Q
+      JPk1JyuuflKb6dJCCEbsCiNVnVYvHvADTWHSM1jrp2iKxOJGPPQdgZuBBDRsHbuiMuFWeH9+
+      wEs2ociDVeq2k+Bh2IoE3yq5rWRLIfhoscenrYAH9teYHbGuI+03q1MIQZAUaIqEQommaYRp
+      TjfKGHeMr0xZ2NzdEUCjqlPk+XU6N9sosoRnagigE6SkRUk3ypCAwxMOZVGgqipxVnBu2eeT
+      ls/+ukWQ5My1+9QsnePTHhOeQVEK5tp9DE1mtmGSi4GTbBayPbvUIysEs80q850QWZIYdyus
+      Bgn9pOD4tDcgrknKejTgH90ow9AU7IpKO0gI04K2nxDnBSu9hJo1IM7dKKPVi0iLAZG/f8rl
+      o8UeHy52GbUNZkYshBCYV1+CkWWJUbvCdN3k3LLPZy2fB/bXkaTByiABTbuCZ2m74wBLS0tM
+      Tu7scONOcYBvm04hBMVVB9gtnV9H9lbp3JWT4L1L8Xu4U7ErDrB3KX4PdyqurX9hePPVtfI8
+      p9/vD20ny/INtfsqpGm6o3Tqncp9V3QKIciy7Ftv5zDZaw5gWcNLUewUkiTtuP+dyu7p3B5C
+      CKIo+tbbOUz2a5HgG8WmihvlAlsNaai8EFueKA6T3W4atpPdqdx2Y71lOhFbvsoyXHbnv8uu
+      z+1NyN76ZLgi4KXf/Zl7Hn2SY7M3VsMlDVZ54cVTHDtyF/PrXWpyiVaf5IcnH9xWLvTXeO3t
+      jzHpEScSgd/DHJ2myDKeefpJtplq3vnHH1FG7+GTyy2mawr9LCNrt5l84DEeOnx9isYmOq1F
+      Tp85iybllCX0VlcxxmeI4oRfPPPUliRLIDj34bsszC/RDmUOTNXYCEPkvk/97hOcvH/rG1HB
+      eou/v/o2zYZFUZasL7Ywm2NsRDm//PlPt9ZZJPz1T3/B8VyiShMraRHGKVHQ58QTz3JwdOsd
+      vbDb5tQb76BLCWkIfUnQ8FwKFJ768ePbzu27//wb3VSir9ap0yXMMtLOGgcf+xlHp68/+9nE
+      2dOvsZS7yMEV4lDQT2OqjTEoS57+yRNb6yxTfv/8C9xzaJbPujLjRkpUFMQry8z84ClOHPjf
+      d7gLJFjguC7STWR7yKrBfQdGWAlKbMvArLqoNzBSy61hGxqm7aBKEp5nI8katjUsHVtitDlK
+      xRtn0hHEpY5Z0bAdZ5sfdgBVhtrIOLZtoykynueApOJUzSGSEmmccvC+E8yOVeimCpapU7Xd
+      4akBqs7kqEMhV6hoCo7rADKOPWRLWsDsgf3Izhhy0sWwHFQFPM/ddmUAWFxcJI4jLMdDEgLP
+      s5E1A8vYfmuyTENW13tgj1EVAYpuUVFlXHe4zua+Q4hoHctxkQHPc5AUneqQ6uVCwPGHTtCJ
+      JJqVlEI2MHQFx3H58me4KyFQZ62NW2ugbvFQ8pchypL2WgfPrdKPc1SRoZou5tCSfYIwjCmy
+      GLVSpe/3cK/2Ufe2v2WUxSFC1uj6AY6pkpYqRdLHrjW2fOAZIAy6bAQJjqUjayZR4ON5Nn6Y
+      0qht/e8mhGB1ZQndssnSDLdqEOUg5TGGXbt6hP/VKPOUTq+PpcuUskES+jiugx9EjDRq287P
+      WruNbQ/mRJcLZN0i9H0azeZQx4vimDTqY1Qder0Ax9JJChnP2T42L7KUNM8J4wxDBdQKceBT
+      azZRtgllsjgkSAoUkaGbNoHv49gmUVpSc+1tzBSsd9awbBs/iKgaCjk6WRTgNkZQP2forjjA
+      HvZwp2KvLtA3CEl/jYV2xsyER7efsLwwx8HDRwkDn7X1dQ7NTvHOm2/RPHiCUc8kyzLKLKG3
+      3ibVPCbrFmrFIAwjTF1B0iyq5p1zOf52YM8BvkEospiun9Aqu7x2+hyuJWhdusClDWhMTHH3
+      XWMszV9ibiXAtBQ8r0l/4TyB6mI5dVbNktbFy6gjIxiaSbU2xmMnj99us24r9hzgGwTNcCmj
+      84QVl6P3HkEufLyRCbzWKvXRcWTF4MTJR0lKBVmRcByH1YpExa1TShpq3mNyfAbd0kiiFN3a
+      mqN8V/Bf57XSZILFoo4AAAAASUVORK5CYII=
+    </thumbnail>
+    <thumbnail height='192' name='Time vs MaxStopProcessCount' width='192'>
+      iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7EAAAOxAGVKw4b
+      AAAgAElEQVR4nO2deXhdZ3ngf2e7q3S175tly7vj7HFWEgIkIcmwFgIkUArTBjpQ2g4UhrbP
+      PNOZh9JOZzqFUlpIC5StlEDZQlgSEuLEsR3H+y7LsvZd9+ruZ/3mD1nCV7ITW+doP7/n8ZPo
+      6uo973fO955vexdJCCHw8VmlyIutgI/PYqJO/U82m+VKBwPDMAgEAp4qNKWDJEmeyrVtG0VR
+      lrxMIQRCCGTZ23eT3/6L6zptAJFIZE6Co9Ho3LW6CLZtI0mS5zfANE00TVvyMh3HQQjhecfy
+      239xXdWLfHcGglwuj23mEXIAVVURjkMkEvZUQR+fxeBVDcDIpnjquT1Ul0RIJ0boi+u89nX3
+      +AbgsyJ4VQMIRGKUFoWRhIWsBqmtLWVkZJSqkjC6ri+bNYDjOJimueRlTrXfcRxP5S6X9k/J
+      Xaj2S5ezDXqxr0iSRCaT8dcAy3wOvNRkLsE1gPdvYx+fpYJ/DuCzqvENwGdV4xuAz6rGNwCf
+      VY1vAD6rGt8AfFY1vgH4rGp8A/BZ1fgG4LOq8Q3AZ1XjG4DPqsY3AJ9VzWU5wwHsfPoJTALE
+      0zpXX3M9bS1186mXj8+CcJkG4CBrUWQ9gyKDYdrk83k/HsCPB1gd8QAAmWQCoQRQFAXh2EQi
+      ET8eYAX4wy81mUsyHgAgGiv1VCEfn6WAvwj2WdX4BuCzqvENwGdV4xuAz6pmhgFY7Nu1k5eP
+      nFocbXx8FpgCA8hlMowmkv6w4LNqKOjrhp4hlcwwMDi0WPr4+CwoBecAJeXVlEY1YtU1i6WP
+      j8+CMmO246BoEUqift5Pn9XBrOm+JCuMjY0thi4+PgvODAPQKCsLU1ZesTja+CwLhBAc6knw
+      /QP9nBvLXHFhlaXEDAMwiMfzjI+NLI42PkseIQSPv9zL6aEU2xtKeOLwAC+diy+2WnNmhjOc
+      gpnPUt7YPONrgq6O0xg2SFoQTQvR0li7YEr6LB0cAWdG0nzqvk1YlsXG+hI+++RJbmotX2zV
+      5sQMA5DIZ+KMTWRmfE1wtuMs0WiYA8c7eMs7H0bXdQzDIBgMeqrQfPrDW5a15GVO1cjyelrh
+      la6OEDiOIJUz6E9kaa6IenofFrr9MwzAwhAqKjM7n8Sa1jXkTYc33Lue9PgQVS1NaJrmud/2
+      VMf3Oh5gPnzMvZY5ktL5xfFBIprCfdvqCAe8k+2VrgpQFFR5+J/3sqm2mAPdCT5+70bP7oMQ
+      AsdxFuxZFRjA6NAIJaUlaIGZb3WJ1vWbZ/2xJEnzUjtgPuUuVZmm7fDY85287dp6ElmTr714
+      jg/duc4T+Y4jsMXkw3Yrz3EEB3oSbKyN0VweRrcEz58Z5b5t3oTICiEW9PkXGMDYQC8Do2PU
+      FVV7fnGfV2Y8Y1ARDbChphjHETx7egTbEajK3DuCEIIzw2n+fV8vhmVzW1slb9hS46pzOUKg
+      Ww6fuHcjncMpHrqxmY8/fnjO8habgnlGUVkFRcEAiurt8OPz6lREA8SzBgd7EjzXPkJFURBF
+      dvcWtBzBZ356AtsRxEIqX3ruLB0jM9d3V07veJY//LeD7OuO87v/ug/HWSHboEY2je4INNXb
+      OE+fV0dVZD505zq6xrKYtuB9t7S4ngbEMwbJnIUkwVBSp740zJG+CVcyJUkiElS5prmUrG5z
+      TVMpEQ/XKgvNrJhgWZYRLF+LXs6URgK8+Zp6zxasqiJzfCDJycEkkgR5y+Gere78vIQQVBcH
+      +eXxIWpjQXRLUBPzdidwISkwgIa1m3hjwzoUzdtUJz6Xx8nBJF9/sYtoQOH37lxHZZG7jpXM
+      m+TN81k2pMkp0VjacCVTliUSWZPWiii6ZSFLUBxyP2MQQnBiMMWvTw0jS/DA9noaSsPzXqCx
+      YAoUCKocO3iQfS+9RCrnfb4Xn0uT1i0+/f0jAIxnDf77D4+5nluPZwyQIKTJqLKEpkiMpnVX
+      Mm1HcHIwyXPtI+zvTvByV5yjLqdVACcGU3xzdxe65ZA1bP7hmQ6GU+50vRxmbbabho4kQyad
+      n/eL+/yG/kSOs6MZTNshnbfY3x3HdHkYqMkSQkDWsMlbDqYtUBX35yu2I3jPjmY+fOda7tlS
+      g+XBoeUThwfIWza6ZWNYDuMZg2dPuXfJEUKQzJmMpg3si7xQZqwBBJYtaKhfQ21VseuL+1w+
+      iiQhSxJt1UUksgaHeieQcDf8G/bsB25a7jurAL76wrnpnzfVue8rgxN5dp8dY3NdDN20OT2c
+      ZltDiSuZjhB8d18vQ8k8AQUyhsMHbmulLPqbKX7B6yCZiNPb2cHJM12uLuxz5cTCGkIIfnZ0
+      kOfaRymPBnC5C0rOsGd/Zs7+7EoJKDICkKRJYwh6sG2eMyxi4QAZ3QZJIqAq5F3qurdznJxh
+      URxSyRg22xpK+OaergI3i4IRIBWfoLZ1LRV1Va4uvBr41clhnm8fprE8yvtvWYPssrc6QhAN
+      qqR1C0We7ABuudj60YslpW45KLKEKkuYtuO6owJkTZv2oRTO+ZNghHBtrId6EuxsH+U9O5pZ
+      XxXhx4eHGE7nMWxn2mgLRoCG1hZSoxOYhj//fyWSeZOXu+L8t/s20lweYWe7+7mq7QjKowF2
+      tJZzy9oKlPNvV8/xcFNFtxxkSfJET1mSsB2BIk/uWNli8jM3xLMmjWVhvvNSD3/zi3YqiwIM
+      TRQurGesiAJoSgZD+Adhr4SMhONMnpaYloPiwcIyHFDI6DYBVcawHDRFdt0BLuZQ6ZWT5dSC
+      0nKEJzaVNSZHPkeA44AqS2QMdx6mGcPi+/v7GMvolEQ0vvZiF/GsgXXB2qjgyY0P90CoCjuX
+      miXMMXP0dHczMDzC4NCoK8WWO0UhlTs2VPLZn50injW4bZ37CDrLFqyvjrK/K0HHSJrm8ohr
+      l+B53kKfxgubEmJSztrKKA1lIWwhXBurZTu0VRfRVl1MTSzITWvKZ+0EFawByiprUOwcSiA0
+      Uz1OHj/MwMAYZ3oGeOtDD0/ncJ+PcLj58AefkusVt6yt4MbmElRV9UR2cVDh1FCaoCoTzxqU
+      hAOTi0wXcu2LbE86jrt7e6m/ddt+9fwaaiiZR4jJmZoqS67kjmcMyiIa6byJIkM4IGPagpxh
+      TbtvFBiAJKts3b6NoeTsoae8spqJpM6tt9/B6EAfJWsasSwL23a/ALqQqQbPR0CE17p6KbMv
+      kWVrfYyHb2pCVST+9qkzGKaN5tIb9CKfutL5oodzwp1MgKAmI0uQylsgTW4LB1XJldymsjCH
+      ehJ88r4NBBSJnxwZ5Gh/krAmT8st3AVKTCAFIlj68AxRErUNrdQ2tBZ8alnW9BvQK+arQIYQ
+      wnNdvZRZFg0xnNIJagrxjIGmyAQ01ZVHaHnRzJEcyoqCrnQW9kXOESTJ9X24qbWCXWfGaKqM
+      4AhBbzzHTa0VruRuqS9hf3eCd395LwB1pWFuWlNOKKBN39cC6aoWIBKJsG3b7OAXn/mlLKLx
+      zhua+B8/Pk5IU/jEvRtdnwME1dkvkYAHC/aZeLHUGJzI88D2OvZ1xVEkifuvqqN/wt1u5D1b
+      ajk9lOahG5sRwqE/keeujdUFL5UCAwhHQ+zdtYeqljWUxIpcXdznyomFVK5tLgWBJ+GQqbyF
+      BESCk7J0c9LNwi2KJGFfML1yG7cAkNEt/uS+TYQ1GYTg9HCGXR3u8lMVhVQ+cncbu86MMpE1
+      +K3rm2gqL0z6NuN1IJFODDMcT7u6sM+Vk8xbHO6b4M8e2Myf3LeRHx7sx22cSU0siCxLFAVV
+      KqMBhBDUlc6eFl0JEhAKyARVmbCmEFBkQpp7Y71nay2P7TyL7Qiyhs039nTx+s3uU3QWBVXu
+      2VrLW66po7kiMsu7dMYEyyanm8QWav/MZxpHCFRZQmLyIMiLJ1AUVCkKqqTyFmkm4wPculgr
+      ssSt6yrZd24cw3IIBRVPtoFft7kaw7L58x8cQ5bhPTta2OyBj9GrMcMAHGQlRJGfG3TBKQ1r
+      NJZF+Lun2zEsm9duqnG9BgBoLo9wx/pKcoZFXyLviWE1lIYZq4wS1hRURSbowQggSxIPbK/n
+      jdtq5yWDx6UoMICR4THqGtwFTfvMDUmSePt1DUzkDBRJojjsPihJkiQUWeJgTwKJyWmW285q
+      O4I9nWP82QNb2FwT5elTo/zs2KBrXReLAgPo6ehEKyomGnY3T/SZG5IkEQtpnp2BhDUF03YI
+      agFs2yGjW1RE3RtWQJE5PZTihTMj1JaEC1wLlhsFBlDb1EpNfZ1rP3SfpUEqbzKS0skYNo7j
+      oJsO58Yyrvzsp3L2dIykkYGj6SQl4eXrO1ZgAPWNDYulx7LDcQR9iTx1pd7MgecD3XJIZE1e
+      t7mahpIQX9rZOXnS6gIhxGSHFxCLqORThidZIYQQ7O+O8+ypEWQJ/tPV9ayrKpr36bi3R6Or
+      BCEEn3j8ELvPjlESDvDN391BWcT91EI3bV7uGicSUNjeWOY6xkC3HFRF4nv7+7AdQURzH2Qi
+      yxK65XBrWyX1sSB7zsXpjedcyQQ41DvB/3uqnfXVRVi2w1/8+Dh/+bbtNJTN74aMXw9vDvQn
+      8hiWw5N/cBvvvqmZXx53X1PNdgT/8GwHEzmTkwMp/n1fj+u1QEiTyRmTMba2I0jpFmGXo5UQ
+      k0m8DvYk2NM5xkhKd22oAD862M9DNzTx6fs386cPbGLH2gqePjn/tep8A5gD4YDCYDLP4d4k
+      R/sniHmQFmQso9ObyPHL48McG0hysCdx0SDuK2FwIo8AZAmmfOrcuhdIQENZmD9+wwbedHU9
+      H7934+TprUuSeZNtjSXIEqiyzFUNJUwsQGaSy54CjQz0IAWL0LQAwrYoLXUXsLycKY8GeMcN
+      Tfz1L05zbXMpr9/sPpeqIkn89MgAG6qLSOZMQgHF9WmYdd6AIoHJx5w1LKyLObNdAbIscdu6
+      Sr7wzBnWV0U52DvBwze3uFMU2Fof4wvPnOFt1zagmzZf39PNwzvcy301LtMABIFQhGMH93Ki
+      a4j73/R2SudXryXPO65v5C1X16KpqicLtd54jobSMCFNoaIowMmBFJYtuIg/22UTOP/Had2a
+      9ZkbJAm+uuscqbxFY1mY996yxrXMB7fX86093fzsyCBIcFVDCbesnf9SXZdnAAKOH3qZkqp6
+      NkXKGR7opyzShK7rBALeZpGbmvd6vfp3HAfT9HZIFR4WhogFZbrGMmR0a9LFQFMQjo1pzv2N
+      rRuz22uYtqv74Aj4i58c45P3buTqxmJ+cmSYv3ryBJ9/19Vzlgnw08N93LG+kvu31SKEw9d2
+      97CnY4Tb2rwxgks9/8szAEnilrvumfWxbdtomrd7wPMVD2Capue6einTRqc4qJIzJuOCZQkU
+      RUVz8ca2xORLJBJQUGSJjG5hOsKVzqbtUBYJ8PDNLViWxdbGct7+xV2u78PhviSfuHcT1cWT
+      TntCUnixY4y7NntTiutSz8pfBC8RVFmioSzCN//zTXzuXddMz9vdUBObPNHPGjbpvIUjoLbE
+      3Sm/LEmMZQx2to+SzFt8e283pR4chJVHg5wYSAKTs4Bj/RNUFs9/jlr/HGCJ0FAWpq4kxJ98
+      7wi2I3j9lhpX4ZAAJWFtMimUPtn5Q5p7b1BZgt+/q41Hv/4yQgjCAYWv/M5NrmQCvPumJj71
+      /SM8e2oY3bIZmND524eucS331ZCEi83mTCZDNBr1Up9VOwUCGE3r/PJ8jbB7trqvETaeMfjt
+      f9nLresqAMHxgRTvvbmFe7a6m1ZMVZ45PZjk+jUV1MSCrtdsQgi6x7M8c3IYTZG4d1sdFdGA
+      dyWoLvGsfANYYjKnMm144Q7sOIL/9cRxwgEVRRJ0x3N8+v7NVBd74+y41Nt/If4aYBUiSfCH
+      r99AbSxESFP46N3rqXI5BVpp+GuAOSKEIG85KKpwncFtvpAkiVhY4723tMzL23olsCpGAHE+
+      y5hXfvZCCB7b2clbv/gif/SdgxgepBz3WRxWvAEIIfjKC+f47M9P8fSJmfmO5sZo2uCZU8P8
+      3Tuvpro46FlElG7a7D47zpG+iWVdeXE5seINYDxj8OTRAcYzBt/a2+2JTNuZTGVeFtEoiwRc
+      +9dMyZz0BjU4MZDi31927w3q8+qs+DWAI+DkYIpTgynqS73xLa+JBamIBnjwC7uoiYX47qO3
+      upY5ljEYnMjhCIGmSAxM5Pmt6xpdFcr2eXVW/AgwltGxbIFhO4x4VHTNsgUZw+K+rbWsqyqi
+      L+E+IERTJI72J3nbtfXc0FJG52h21SUnSOZMnjoxzHPto54U3bgcVrwB6KZDzrTJmw4p3RvH
+      tZG0zq9ODNM9nmVP5zhH+hKuZVq24OrGUn54sJ+DPQnWVUVX1RRoKJnni7/uoCSsIQGf/1V7
+      gRfrfLHkpkC2I5Bl7yxTlib/RQLKtH+8W5I5E02dzIhWEtJIZN17mVZEA9SVhmgsDZPMmVzX
+      XOZJysHlwhOHB3hkRzN1JSGEEERDGs+3j3LfNm+c4S7FZccD7N/7InndwJKD1Deuoa2lznNl
+      BhI5/vA7B2mpiPCZt17lSUnPuvM+9oblsL7Gm0xjZefTDFZEA5wdyXiSakSWJR59zTqO9iUI
+      aQqb6mKragqUNayCgttlkQCdI5l5v+7ljwBqECsxQtdojqbWDeTzedLpNPF4nEAggK7r00N2
+      KBTCMAyc8wUagsEgtm1P+85PHchM+WerqoqiKPzH/j6EkWP3mQyHz3RTGZ40AEmSCAaDs2Re
+      WJ8gEJjslBfKlGUZwzD45B1VPH8uxft21NPdPbkTJMvyRfU2TXNa5qX0jqdztBRBKjlBddBE
+      0tN0d3fPkjkXvWtUBQmJ3p7J4tOKoqBpGvl8vuBevJLegUAA53yswtTvDMNAUZSC3021SZIk
+      DMMoeBa6rl/0Pl3YJsMwUFX1ip7Fpdq0Pib49q527moJYdoOP+80uL0pMP28Xk1vRVFQVfWS
+      eluWRVFR0axncdm+QCMDPdhyEC0YRlgGlZUVnvsCjWcM/vsPj9JSEeWP3rDB0ymA1yehL5wZ
+      5ekTg6yrKuY9O5o9e1svtC/MUpEphGBP5zgvnBlFluC+bXVsqi32neG8Yql3gClWqwFM4TvD
+      +fgsIL4B+KxqpqdA2Wz2ived8/k8oZC3iXSnFiheT4Fs2/Z8WJ0PmVMVMv32L0z7p3eBIpHI
+      nAT7a4DlPQdeajL9NYCPzwLiG8AKRwjBwESOc2NZT7xWVxpLzhXCxzuEEPzoUD/9iTxFAZmf
+      Hh3mw3et8yQ73ErBvxMrmKxhc2Y4zaN3ruVdNzayvqaIQz3uHfdWEv4IsIIRQCJr8ve/OoNu
+      WkiSzB3rKxdbrSWFPwKsYEKqTG88h2k7VBcHebFjzHVirJWGPwKsYFJ5ixtby3hwez2prM7a
+      6mK6xrOsqy5abNWWDP4IsIKJhTWSOQvbmRwBdp8dY0tdbLHVWlL4I8AKRpbg9+5o5QeH+snk
+      TR7cXk9NbHVNgRwhGE3ppPMGjeXKrB0w3xt0icn0T4K9a7/tCL65u4ucaRPWZIZSBr99SwvV
+      sd+47/gjgM+KZVfHKDUlIe7ZUoNlWSTyDt/e281H726bjjPw1wArnJxh8+TRAb53oJ+hifyq
+      CrQ/PZTimqbS6c5eWRTAtB2MC07EfQNYwThC8OWdZykJa1xVH+OfX+hckMqLS4Xm8gjtw+lp
+      o0/lLSRJQrsg1vyyg+JHBnqRQ8XIioKwbcrLVnuZvKVPMmeiyBK3rK3Asizu3FDFwZ4Ed210
+      X9VyOXDnhmq+9FwHPeNZigMyRwfSPHRjU0Ey48teAwjhcHjfi3T0DPHgW985Lwr7eEskoDKR
+      M9EtBxk4M5zm5gWovLhUCKgyH76rjbMjaSayOndvqZ1Veuoyd4EEne0nGRoehmCMcKSIjWub
+      yGazFBd7k2pk+krzWCXS652l+ZDpdfuPDaR48uggkhBsrCvhgatq3JYfnmY+2j9fci8l098G
+      XWIy52Mb1LIddNMiEtQ8fbEsl/bDpXX1t0FXAaoiIxxpVSXaulz8XSCfVY1vAD6rGt8AfFY1
+      vgH4rGpmGICgq+M0Z7sHFkcbH58FpsAAHEfn6JHjjI6NL5Y+Pj4LSsE26OhAL44cIJuZ/7zs
+      PsuXjG7xry+eI54xWFNZxLtualqytZJfjYIRoLphLYqZwFHcF3zwWZkIIfjisx286ZoGPv6G
+      9WyqLeZbe7ypvrkYzFgDGJh2kIpSb90bfFYOtiNwhKChNIwkwXUtZXSPZxdbrTkzwwBUqqrL
+      sMzV4zLrc2XIsoRhO5jnferjWYOQ5q3bwkIywxVCIhQOEwytrrhRn8tHliTedWMzf/Wzk0Q0
+      mbwl+C+vbVtstebMDAOwMSwJIz4OtC6KQj5Ln7bqIj71xk1kcwZFkeCyXQDDrCmQRmq8n0CR
+      nzrD55VRZZlwQFnWnR9mjQAmqUSOcN595XMfn+XALFcIW5ikk8t3Ve/jcyUUjACpZJqq+nqK
+      K8oWSx8fnwWlYAQ4e+wAL+0/yJmuvsXSx8dnQSkYAerXbuT6pEVRbd1i6ePjs6AUGEB8oIf+
+      sTgb69bM+Jqg4+Qx+gcGmNBh0+ZttLX4RrLUEUIwmMzzgwP95AyTOzfWcF1zqR8aeQEFBlBZ
+      30xTPIMzs5aUAFVVaGhsZPDIKWwxWSJV13UCAW/9huYzK4Tp8Qn3fMicav9UuVg3OAK+8nwn
+      j+xoIqrJfG1PD5VRlfoSb0rbzkf7p+R60f6ZMi+ma4EBWJZNrLSC4rLZ5wBqIISmRbjv3nsR
+      tkUoFMK2bc+zAvhZIbzLihDPGJRFgzRXFmOaJre1VdExkqOl0htfr/lqvyzLi1Mmtbq+jlwy
+      SW9XB8kLU+hJEg3NrdTX1VAcDROL+c5yy4FYWCORNeiNZ0nlLV7oGGNTnf/sLmRWWhTLNFDC
+      YXLpPLGwt9bts7DIEnzg9lZ+cKCPnGHxuk011Hk0/VkpzDAAgWnZNNY1U1PlvymWO5IkURML
+      8eid6+ZlurISKJgC5bI5jFyWoZH4Yunj4+MpjiPoGstwcjBN3rRn/b5gBEiOD5HM2YRsa8EU
+      9PGZL0zb4SsvdBJUFaIBmSePDfGeHc00lkWmv1NgANUNzYSUA6j+UOnzCgghGEnpdAwn2dZY
+      RlFQ9WTbWgiB7QiEEMiycC1zZ/so62uKuWtDFZZlkTYEX9t1jj94/fppL9YCA5AkhQ2bN2Ko
+      kYsK9PEBePrkMCcGkmyojvK5p9t5xw1NbKhxt2a0HcF/HOjj7MhkQYsb1pRz96ZqV0bQOZrm
+      we310zLKogFsITBth6A6uc06Ky/Q8PAogYA/AvhcHNsR7O0c5yOvbePujVV88r5NfO/lXtdy
+      nz01TElY5b++YQN/9Pr19CdynBhIuZK5rqqIY/0T04eL4xkDRZYIXLpCjGCwdxCluBzaWlxd
+      3GfpYDuTUwtVuJ9WwOT26hSKLOFF1bFj/Uk+eHsrkjQp8471VezqGGNL/dyDs25vq+Sru87R
+      NXaOqCZzbjzHwztaCu7BDANQUeUsiawfFL8SEEJweijNDw72IRyHa5rLuXdrjSsjkCWoKg7x
+      5z88hmFN7qrcf5V7v7Cq4iC98RzrqyfrTZwdzdBYFnYlU1VkPnB7K/2JHMmswZuvbSQ4I4B/
+      hgFYRMsaaGmsdXVhn6WBaQu+sbuLbQ0xdNNm37lx2qqLaKsuciV3LK1z27oKusbS1JdFOTfm
+      PoDqTVfX80/PdVAXC6FbDrrl8IHb3cely5JEY1kEs0hDu0j2illZIYIBDUd464jkszhkdIvj
+      A0nefE09JSGFl7vPcnYk7coAbGdywvPGq+qmD9c+89MTrnWNBlU+evd6uscyyBI0VxShyPPv
+      tTpjESxRUhpjcHBo3i/ss3CosoQiS57UBpNlCdN26Itn2deV4NxYhmjAG8c1TZFprYzSXB5Z
+      kM4PF/EF6us6S1HzlgW5uM/8Eg2qbK6LcWwgiW5YVBYFWVPprqabLEm0VET5yLcOYNoOAvif
+      b9nmjcKLwKy8QIFwKXVV5YujjY+naIrEu29q4mu7zmHZDnduqGa9y/m/7Qi6x7M8/uFbMUwT
+      VVX5m5+f4rrm5RlHXmAAZ9v72HjVVvI5Py3KSuHUYIq26iKKAgpnRzMYFxwCzRVZmvynyhKq
+      R9ugi0XBGsDITnDy5EnGU35alJVAxrA5N5blkZtbuG9bDZvqijnUM+FKpixBXUmYXxwbYixj
+      8NVd57itrdIjjRcev07wEpPpZURYRrf4+HcPsaYySlCR6BzN8p4dzexwWS1eCMELZ0Y52pfg
+      NRtq2FxX7FkI6yLXCTb5+Y9+Qc26Nq7ZutFTBXwWHlmSyBk2xSGVWFDhcF8STXH/YpEkidvX
+      V7FjTemyjzGYYQAyZj7O6MTsKVBisJOxvIptWwSDYf+wbBlg2g7XtpTx5qsbSOcNaksiZI3Z
+      PvGrmVm7QOmsQfFF3hKSlWNwWOfY4f28+R0Pk8/nMQyDYNDbVOpT2QC8ngI5joNleRvnMB8y
+      hRDT/9wS0SQiqsTus6OUhlR2d47zB3ev80znpd5+AEcIusdzTGQNNtbGCGmF/WrGGiDPz3/8
+      DC1btrJpXXPBF63MGN2jOSRZRlgWrWua5mUNMF8GYFkWqjrr2GPJyfS6/bYjONqfZCKjc0Nr
+      BRGPDq1gftovhMBxHE/WAKbt8OWdnZRFNIoCMicG0zx0YzMtFZcIiOnvHSRWGkXXjVnC1GgF
+      a2f0dUmS5iXJ0nzKXeoyJUlCeOS1CaAqEtc0lZ5fBHrbWcH79k+13Qu5z50eZXtjCbe3VWJZ
+      Fndugn95vpOPXRAQU/CaGejuQYtECYf9CjGLQc6w+dXJYfZ2jk/73PjMna7xDBtqfrNDFQup
+      OOcDYqYoMICmdRu4/vrr2dDatLCa+mA7gs//qh1NkRlK6Xxjd5dn8+DVyvrqYg71Jqbv41ja
+      QFXkSwfEVNfULKyGPtOMpXViYY071lfiOIK/+eXpySAWxc/jOVdubavgGy928dlrSycAAAml
+      SURBVNjOTsKaxEBS5703r3mlgBifxaIkojGW1hmYyDORNQhrCvICeUSuVFRZ5n23rmE4qZPK
+      6bRUFhNQX3EX6MrwT4K9ldkbz/KTQ/2ENYW3Xd9Iccg72V7rms5b9IylWVcTm9Wp3LDQJ8G+
+      ASwxmQvdAebCC2dG+dzT7dTEggynDP7q7VfRUuFNP1hkVwgfn1fGdgRff7GLf37/jQRlwVDa
+      5HNPt/PXv3X1Yqs2J7x9zfqseBwhCAeU6SiwhtLwsnav8A3A54qYCq98sWOMlG7x3X29bKxd
+      vomUfQNYBVi2g2l7418jSRKfvn8zPz48wIe+cYDeeJZHX7POAy0XB38RvMRkerkIFEJwvD/J
+      T44MgBBsqS/hge11nlV3X+rtv5DLqhDjs7IwbcEPD/XzoTvX8egdrYymdc4MpxdbrSWFvwu0
+      gskaFgMTef7x1x2oEoykDdZURF0nsl1J+CPACiaoKvSMZ7m9rZIHrqplMJknGvTfeRfiG8AK
+      xrAdbmurYDxj8HJ3gvu31V20SsqVIoQgmTM5PpBCN+0l7bQnhEC3bLLGxfX0XwcrmFhIJRbS
+      yJs2pWGNAz0T3L/dfSLbne2jk+nMQyrf3d/HB25rZW2Vu3xD84EjBD851M+poTSqNJks97dv
+      XVNQ/NE3gBVONKjy+Mu9GJbD1voYqksHO8cR/NNzHXQMZxhN67RWRrFswWffvt2VXCEEJwZS
+      /PhQH5oi884bm2goDbsKjDnQnSCRM7m6qYREWqehPMq393bze69ZOy13VRiAbtn0xXOsqVQ9
+      87A0LYc9neNsbSijLBrwROZTJ4b44jNniAZV/vSBzWysnXtufICMbvOFZ84wMJEH4MRgkvu2
+      1XH7+rnn8bGFYH9Xgtz5qVT7cJrikPtudKh3gvf9yx7S+ckY4+8f6OM7j95CQ+ncU6Tv747z
+      gwN9xLMG0YBCKm9zbXMppi0IqBeJCHslOtuPc/rUKbp6++jtm5/kubbj8OTRQfZ3e1el0rId
+      HnlsL3f/35385ZMnPZHpOIL3fWUv//sX7bzlH16gL+4+kVhfPMdHvrWfoKYwktb50Df2F0Qu
+      zYUzI2kGJvLcs6WWR3Y0g5B46dy4a11zps39V9XxpUeuY1tDiSeuEF98toNrmsr42cfu4Psf
+      voVoUOWbu7tcyRzPGLRURHn6j+/ipx+9jU+9cRMnBwurzlym6TqMJ7NkRvs40T3KWx96BNM0
+      0XUdwzBQVRXLsqbjOVVVxbbt6QBvVVUnC6DZkzdq6pDjwp8lSeLnx4b45t4ekgY89vB2ysJK
+      gcypawBomvaq15AkiSN9SYKyzS9//1o++G+n+PAtk0E/bmQe6Jkgpjp8/m2beeLoMN/a3ckH
+      d9QhyzKKosy6FxdeQ1VVHMeZdY1j3QkaYkE+//aNZA2b1/zdHoZHx4kGVRRFwTTNK9Z7YDSB
+      pkisLQ9QHtUoiyiMTGSYmJiY1aap7A6yLCPLcsHPF7bJcgTFIZWmshDPn+zluqYS9p6Lk0gk
+      XvW+zZR5YZvG0jq/c3M9FZpJuSp481XVnB3NMT4+PmeZpweTCNvihfZhioIypwfiJHMG3YOj
+      lEdUVFW9XAOQiEWCBOtbuavtGhLD/ZSvaUKWZVRVnXVqO6Xc1ANSFOV85T95WtmZ/5UkiaaK
+      IuI5i7KiMMWRIBemsLyYzFe7hiRJNFYUcbQ/xQe/fojSWPH0aeDUafOVygRoqSzm5FCanx4d
+      5sljw7z75rVomnbRE+yLyZw67bxQZnVJmJ54jv/z1BnGMgalYY1QUENVlQKZV6J3WXEI0xY8
+      fXKE4pDKUFKnNBoseGZT/52aE0/Jnvp5ZpskR5A3bR7b2UlAssnZMtubJhNkzcxoMfNZXFKm
+      JBHWVB5/uZ+GklbyhsUTRwa5rqVi+nld6lm8kszWyig4NqoiM5IyuLa5nF+cGKWsKISmSJP3
+      bam5Qgwnc4Q1heKwN/NqgJODSXaeHuat1zVRWeRNwP+LHaM8tvMsd6yv4v23ua9kAvCFZ9r5
+      +191EA0qfOZtV3HPFnfJx4QQfOzfDvGjQ30ArKmI8viHbqWy2N29/fJzZ/nLJ0/gCAhpCv/4
+      yPXctbHKlcwXzozy/q/sPa83FAVVvvf7t7LOxe5Sz3iWd31pN1vqY5SGVXa2j/Gx16/n3Tf9
+      JuXPkjMA3xfIe1+Yw70JJrIGO9ZWeha9dWowyWAiR1tNMQ1l3pTVPdY3wRNHBlAkeOimwoLW
+      c6U3nuXbe3oYy+R5cHsDt7VVFOws+QawxGQuh4iw+ZTpO8P5+CwgvgH4rGqmd4Gy2ewV+3Tk
+      83nPFZq5VeoVhmEQCHi3sJ4vmbY96bPidc7N5dL+qS3ihWr/9FUikStfcEiSNKe/eyUMw0CS
+      JM/nlvOh63zINE0TIYTnHWu5tN+2bUzTJBQKeSr3Urq6WgQD06OGZ0lShUB4KQ8uGNkkvBMr
+      mBI7H7ouF5ne3tOFb7/rNcBLu57jqWefdytmmlRigKee3e2ZPIB8Os6vn/oZw6nZWa/njLB5
+      /pc/ob3HvWvBhYwPdPDMroOeyjxz6AV+/vwBT2Vm4gP8x/d/RNrwtqh695ljPL3zJU9l9rcf
+      5F8ff/Kiv3NtAGogTDjo3XSluKycsMdpvGVZRo2WUxbxUK4QNLSsJZNOeCcT6O8fJJ/1tkhh
+      We1aFDOJl13VzGXRNBhPebsODMgyV19/racyUxmL8tLIRdvvegqUz6YwHJVY0dy99gpxyGZ1
+      IhGv5IGpZxkem6C6ugbNszR+gvjYGEUl5R7KBIRDXjcJhbxLUW/qOVI5k/JSd96lFyKEw/hY
+      nLKKCrxMYarndbRQ0NPtSdvUSaTzVJSVzPqdawPw8VnOrIp4gOVG98nDmCV19Jw6wbXbtyCp
+      QVRNIxRUObBvH5GSckzTpqG2mnAkiG44xMIyz724j4rKahoaGpAkiZAiEEqAXDZHOKggZI1c
+      LkdFRTntxw6TExrrW5twkFFlMEwLy3bo7e3h6u3uAlyWC74BLEGyyTy9A/uI5zSOH3qJnFJM
+      Omvw4D13Eo2ESaYTDHScYXSgmt7xNGvrq7jhui3EJ1JURWVe3DtIpZohoZRS6mToHM9TW16E
+      ZVkMjqZ401sfZDxlsHVzMwcPHsQwsoRxONqXoq66CkUTLM9Mn1eObwBLkKqmZuRcBZtCIdLj
+      o5TJAYKxEhxHIJCoqm6koriYVCaPKWwqqmvRAmF23HwLDWUhSsZyTMTHqAsrGJYgWK5TXhLB
+      dASVVTmCWpCW+nJ6h8dZ09RAXmjk4wPcWLOW8pJidFNf7FuwYPx/LV/Yrc58EhcAAAAASUVO
+      RK5CYII=
+    </thumbnail>
+  </thumbnails>
+</workbook>


### PR DESCRIPTION
Major changes are:

1. Add the latest-departure-trip to the stop state and don't allow the same trip in labeling the next stop.  Since the latest-departure (and its trip) define the time window, during the labeling, we don't want to assume we can use the same trip again for the next link label, because if we choose it, we'll be forced to choose it again.

2. When we update the stop state for a stop that's already been processed, it may affect other reachable stops, so mark it to reprocess (by putting it back on the label queue).

3. Make the label queue smarter: if we add a stop1, labelX then stop1, labelY, only the lower label is valid.  So a stop can only be in the queue once at any given point in time.

4. Make the maximum number of times a stop can be processed a configurable number.  (So setting it to one is similar to the previous version of this code.)

5. Return and write basic performance measures: milliseconds spent doing labeling, milliseconds spent doing enumeration, number of labeling iterations executed, maximum number of times a stop was processed.